### PR TITLE
Added Kitty config and zsh usability tweaks

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -99,3 +99,4 @@
             src: "./templates/mc.ini",
             dest: "~/.config/mc/ini",
           }
+        - { name: "Kitty config", src: "./templates/kitty.conf", dest: "~/.config/kitty/kitty.conf" }

--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -1,0 +1,47 @@
+#
+# kitty.conf
+# {{ ansible_managed }}
+#
+
+# --------------------
+# Font configuration
+# --------------------
+font_family      Fira Code
+bold_font        auto
+italic_font      auto
+bold_italic_font auto
+
+# Fallback fonts
+font_family      JetBrains Mono
+font_family      Symbols Nerd Font Mono
+
+font_size 13
+
+
+# --------------------
+# Color scheme
+# --------------------
+# Choose ONE of the following
+
+# Dark mode (WezTerm: Tomorrow (dark))
+include themes/Tomorrow_Night.conf
+
+# Light mode alternative (WezTerm: Sonokai)
+# include themes/Sonokai.conf
+
+
+# --------------------
+# Tab bar behavior
+# --------------------
+hide_tab_bar_if_only_one_tab yes
+tab_bar_edge  top
+tab_bar_style separator
+set_titlebar  yes
+
+# --------------------
+# Key mappings
+# Option (Alt) + Arrow word navigation
+# --------------------
+map alt+left  send_text all \x1bb
+map alt+right send_text all \x1bf
+map alt+.     send_text all \x1b.

--- a/templates/zshrc.sh
+++ b/templates/zshrc.sh
@@ -81,6 +81,11 @@ precmd_functions+=( precmd_vcs_info )
 setopt prompt_subst
 zstyle ':vcs_info:git:*' formats '%b'
 
+# ^x^e opens editor with the current command
+autoload -z edit-command-line
+zle -N edit-command-line
+bindkey "^X^E" edit-command-line
+
 # zoxide
 if type zoxide &>/dev/null
 then

--- a/templates/zshrc.sh
+++ b/templates/zshrc.sh
@@ -115,6 +115,7 @@ chpwd() {
   if [ -f "$PWD/kubeconfig" ]
   then
     export KUBECONFIG="$PWD/kubeconfig"
+    echo "kubeconfig is ${KUBECONFIG}"
   fi
 }
 

--- a/templates/zshrc.sh
+++ b/templates/zshrc.sh
@@ -86,6 +86,9 @@ autoload -z edit-command-line
 zle -N edit-command-line
 bindkey "^X^E" edit-command-line
 
+# space expands !!, !$, !v (last command starting with "v")
+bindkey " " magic-space
+
 # zoxide
 if type zoxide &>/dev/null
 then

--- a/templates/zshrc.sh
+++ b/templates/zshrc.sh
@@ -102,6 +102,14 @@ function nvm_init {
 export PS1="$ "
 export RPS1=$' %F{cyan}${vcs_info_msg_0_:0:12}'"%F{green} %3~ %*%F{white}"
 
+chpwd() {
+  # Set KUBECONFIG when a local kubeconfig file exists in the CWD.
+  if [ -f "$PWD/kubeconfig" ]
+  then
+    export KUBECONFIG="$PWD/kubeconfig"
+  fi
+}
+
 if [ -e "$HOME/.zshrc.local" ]
 then
   source "$HOME/.zshrc.local"


### PR DESCRIPTION
  - Add templates/kitty.conf with fonts, theme include, tab bar settings, and key mappings.
  - Wire the Kitty config into site.yml so it gets installed to ~/.config/kitty/kitty.conf.
  - Improve templates/zshrc.sh with edit-command-line binding, magic-space, and a chpwd hook that sets
    KUBECONFIG when a local kubeconfig exists.
  - Testing: not run (configuration changes only).

  Files:

  - site.yml
  - templates/kitty.conf
  - templates/zshrc.sh