### PR TITLE
Inline One Dark theme in kitty config

### DIFF
--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -19,15 +19,47 @@ font_size 13
 
 
 # --------------------
-# Color scheme
+# Color scheme (One Dark)
 # --------------------
-# Choose ONE of the following
+foreground              #abb2bf
+background              #282c34
+selection_foreground    #282c34
+selection_background    #98c379
+url_color               #61afef
+cursor                  #528bff
 
-# Dark mode (WezTerm: Tomorrow (dark))
-include themes/Tomorrow_Night.conf
+# Basic colors
+color0   #282c34
+color1   #e06c75
+color2   #98c379
+color3   #e5c07b
+color4   #61afef
+color5   #c678dd
+color6   #56b6c2
+color7   #abb2bf
 
-# Light mode alternative (WezTerm: Sonokai)
-# include themes/Sonokai.conf
+color8   #3e4451
+color9   #be5046
+color10  #98c379
+color11  #d19a66
+color12  #61afef
+color13  #c678dd
+color14  #56b6c2
+color15  #ffffff
+
+# Cursor and selection tweaks
+cursor_text_color       background
+cursor_beam_thickness   2.0
+cursor_shape            block
+
+# Tab bar
+active_tab_foreground   #282c34
+active_tab_background   #61afef
+inactive_tab_foreground #abb2bf
+inactive_tab_background #3e4451
+
+# Bell
+bell_border_color       #e5c07b
 
 
 # --------------------


### PR DESCRIPTION
## Summary
- embed the One Dark kitty color scheme directly in `kitty.conf`
- remove external kitty theme files and the associated Ansible copy step

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6957a0db299c8328a8b2ec680c0e95a9)