### PR TITLE
Add cmd number tab switching for kitty

### DIFF
--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -77,3 +77,14 @@ set_titlebar  yes
 map alt+left  send_text all \x1bb
 map alt+right send_text all \x1bf
 map alt+.     send_text all \x1b.
+
+# Command (⌘) + Number tab switching on macOS
+map cmd+1 goto_tab 1
+map cmd+2 goto_tab 2
+map cmd+3 goto_tab 3
+map cmd+4 goto_tab 4
+map cmd+5 goto_tab 5
+map cmd+6 goto_tab 6
+map cmd+7 goto_tab 7
+map cmd+8 goto_tab 8
+map cmd+9 goto_tab 9


### PR DESCRIPTION
## Summary
- add macOS Command+number shortcuts to switch kitty tabs directly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6957a474e49c8328bd3529c63eeeca6d)