### PR TITLE
Dim inactive kitty tiles

### DIFF
--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -97,3 +97,8 @@ map cmd+9 goto_tab 9
 
 # Resize tiled windows with mouse drag (Command/Ctrl + Left Click)
 mouse_map cmd+left drag resize_window
+
+# Open new windows and tabs in the current working directory
+map ctrl+shift+enter new_os_window_with_cwd
+map ctrl+shift+n     new_os_window_with_cwd
+map ctrl+shift+t     new_tab_with_cwd

--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -95,6 +95,12 @@ map cmd+7 goto_tab 7
 map cmd+8 goto_tab 8
 map cmd+9 goto_tab 9
 
+# Resize tiled windows with keyboard (Ctrl+Shift + Arrows)
+map ctrl+shift+left  resize_window narrower 5
+map ctrl+shift+right resize_window wider 5
+map ctrl+shift+up    resize_window taller 5
+map ctrl+shift+down  resize_window shorter 5
+
 # Resize tiled windows with mouse drag (Command/Ctrl + Left Click)
 mouse_map cmd+left drag resize_window
 

--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -55,7 +55,7 @@ cursor_shape            block
 # Dimming inactive tiles
 # Use text alpha instead of dimming inactive windows
 dim_inactive            no
-inactive_text_alpha     0.80
+inactive_text_alpha     0.60
 
 # Tab bar
 active_tab_foreground   #282c34
@@ -94,3 +94,6 @@ map cmd+6 goto_tab 6
 map cmd+7 goto_tab 7
 map cmd+8 goto_tab 8
 map cmd+9 goto_tab 9
+
+# Resize tiled windows with mouse drag (Command/Ctrl + Left Click)
+mouse_map cmd+left drag resize_window

--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -52,6 +52,10 @@ cursor_text_color       background
 cursor_beam_thickness   2.0
 cursor_shape            block
 
+# Dimming inactive tiles
+dim_inactive            yes
+dim_opacity             0.80
+
 # Tab bar
 active_tab_foreground   #282c34
 active_tab_background   #61afef

--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -53,8 +53,9 @@ cursor_beam_thickness   2.0
 cursor_shape            block
 
 # Dimming inactive tiles
-dim_inactive            yes
-dim_opacity             0.80
+# Use text alpha instead of dimming inactive windows
+dim_inactive            no
+inactive_text_alpha     0.80
 
 # Tab bar
 active_tab_foreground   #282c34

--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -95,16 +95,10 @@ map cmd+7 goto_tab 7
 map cmd+8 goto_tab 8
 map cmd+9 goto_tab 9
 
-# Resize tiled windows with keyboard (Ctrl+Shift + Arrows)
-map ctrl+shift+left  resize_window narrower 5
-map ctrl+shift+right resize_window wider 5
-map ctrl+shift+up    resize_window taller 5
-map ctrl+shift+down  resize_window shorter 5
-
 # Resize tiled windows with mouse drag (Command/Ctrl + Left Click)
 mouse_map cmd+left drag resize_window
 
 # Open new windows and tabs in the current working directory
-map ctrl+shift+enter new_os_window_with_cwd
+map ctrl+shift+enter new_window_with_cwd
 map ctrl+shift+n     new_os_window_with_cwd
 map ctrl+shift+t     new_tab_with_cwd


### PR DESCRIPTION
## Summary
- enable dimming for inactive kitty tiles
- set dim opacity to 0.80 for inactive windows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6957bd1e6b348328b564849b001d0971)