### PR TITLE
Add Gemini configuration and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Gemini Code Assistant Project Overview
+
+This project uses Ansible to automate the setup and configuration of a development environment on macOS. It installs various tools and applications, and deploys configuration files for them.
+
+## Project Structure
+
+- `site.yml`: The main Ansible playbook. It defines the tasks to be executed.
+- `roles/`: Contains Ansible roles, which are modular units of automation.
+  - `cp`: A role for copying files.
+  - `fish`: A role for setting up the Fish shell and related tools.
+- `templates/`: Contains template files for configurations (e.g., `wezterm.lua.j2`, `vimrc`).
+- `README.md`: The project's README file.
+
+## How to Use
+
+To run the full playbook, you need to have Ansible installed. You will also need an inventory file. The `README.md` provides an example of the inventory file structure.
+
+1.  **Create an inventory file** (e.g., `inventory.yml`):
+
+    ```yaml
+    all:
+      hosts:
+        some_host:
+          ansible_host: localhost
+          ansible_connection: local
+          ansible_user: your-username
+          ansible_group: your-group
+    ```
+
+2.  **Run the playbook**:
+
+    ```bash
+    ansible-playbook -i inventory.yml site.yml
+    ```
+
+### Running Specific Tasks
+
+The playbook uses tags to allow running specific parts of the setup. You can use the `--tags` flag to specify which tasks to run.
+
+- `configs`: Copies configuration files.
+- `fish`: Installs the Fish shell.
+- `fisher`: Installs the Fisher plugin manager for Fish.
+- `starship`: Installs the Starship prompt.
+
+For example, to only copy the configuration files, you can run:
+
+```bash
+ansible-playbook -i inventory.yml site.yml --tags configs
+```

--- a/site.yml
+++ b/site.yml
@@ -100,3 +100,8 @@
             dest: "~/.config/mc/ini",
           }
         - { name: "Kitty config", src: "./templates/kitty.conf", dest: "~/.config/kitty/kitty.conf" }
+        - {
+            name: "Gemini config",
+            src: "./templates/geminiSettings.json",
+            dest: "~/.gemini/settings.json",
+          }

--- a/templates/geminiSettings.json
+++ b/templates/geminiSettings.json
@@ -1,0 +1,20 @@
+{
+  "context": {
+    "fileName": [
+      "GEMINI.md",
+      "AGENTS.md"
+    ]
+  },
+  "security": {
+    "auth": {
+      "selectedType": "oauth-personal"
+    }
+  },
+  "ui": {
+    "theme": "Default"
+  },
+  "general": {
+    "previewFeatures": true,
+    "enablePromptCompletion": true
+  }
+}


### PR DESCRIPTION
- Add `AGENTS.md` with project overview.

- Add `templates/geminiSettings.json` with initial configuration.

- Update `site.yml` to deploy Gemini settings.
