### PR TITLE
Add Firefox uidensity config to Copy configs

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -175,3 +175,8 @@
             src: "./templates/codex/rules/npm.rules",
             dest: "~/.codex/rules/npm.rules",
           }
+        - {
+            name: "Firefox user.js",
+            src: "./templates/firefox/user.js",
+            dest: "{{ firefox_profile_dir }}/user.js"
+          }

--- a/templates/firefox/user.js
+++ b/templates/firefox/user.js
@@ -1,0 +1,1 @@
+user_pref("browser.uidensity", 1);


### PR DESCRIPTION
Summary
- add a Firefox user.js template that sets browser.uidensity to 1
- include the Firefox template in the existing Copy configs loop in site.yml

Notes
- destination uses {{ firefox_profile_dir }}/user.js