### PR TITLE
Add television shell integration

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -45,6 +45,7 @@
           - pwgen
           - ripgrep
           - starship
+          - television
           - tig
           - watch
           - yamllint

--- a/templates/zshrc.sh
+++ b/templates/zshrc.sh
@@ -88,9 +88,9 @@ then
   eval "$(zoxide init zsh)"
 fi
 
-if type fzf &>/dev/null
+if type tv &>/dev/null
 then
-  source <(fzf --zsh)
+  source <(tv init zsh)
 fi
 
 # NVM


### PR DESCRIPTION
## Summary
- install the television Homebrew formula
- initialize television shell integration from the zsh config

## Testing
- not run