### PR TITLE
Update tooling config and improve agent skill templates

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -49,6 +49,7 @@
           - television
           - tig
           - watch
+          - worktrunk
           - yamllint
           - yq
           - zellij

--- a/templates/mise.toml
+++ b/templates/mise.toml
@@ -2,4 +2,5 @@
 _.path = "/Applications/IntelliJ IDEA.app/Contents/MacOS"
 
 [tools]
+node = "25"
 pi = "latest"

--- a/templates/opencode/skills/creating-pull-requests/SKILL.md
+++ b/templates/opencode/skills/creating-pull-requests/SKILL.md
@@ -56,18 +56,27 @@ Common verbs: Add, Fix, Update, Remove, Refactor, Implement, Improve, Replace, E
 
 ## 1. Gather Context
 
-Before creating the PR, understand what's being changed:
+Before creating the PR, understand what's being changed. Detect the default branch dynamically instead of assuming `main`:
 
 ```bash
-# See all commits on this branch vs main
-git log main..HEAD --oneline
+# Detect the default remote branch, e.g. origin/main or origin/master
+git symbolic-ref --quiet --short refs/remotes/origin/HEAD
+BASE_REF=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##')
+
+# See all commits on this branch vs the default branch
+git log "origin/$BASE_REF"..HEAD --oneline
 
 # See the full diff
-git diff main...HEAD
+git diff "origin/$BASE_REF"...HEAD
+
+# Get the merge base for precise comparisons
+git merge-base HEAD "origin/$BASE_REF"
 
 # Check current branch name
 git branch --show-current
 ```
+
+If `origin/HEAD` is unavailable, inspect `git remote show origin` and use the reported HEAD branch.
 
 ## 2. Identify Links and References
 
@@ -80,8 +89,10 @@ Ask the user or search for:
 
 ## 3. Draft the PR
 
+Prefer `--body-file` or a single-quoted heredoc saved to a temp file. This avoids shell interpolation bugs with backticks and inline code spans.
+
 ```bash
-gh pr create --title "Add feature X to service Y" --body "$(cat <<'EOF'
+cat > /tmp/pr-body.md <<'EOF'
 ## Why
 
 [Motivation here]
@@ -98,7 +109,20 @@ gh pr create --title "Add feature X to service Y" --body "$(cat <<'EOF'
 
 - [Ticket](url)
 EOF
-)"
+
+gh pr create --base "$BASE_REF" --title "Add feature X to service Y" --body-file /tmp/pr-body.md
+```
+
+After creation, verify what GitHub received:
+
+```bash
+gh pr view --json title,body,url
+```
+
+If formatting was mangled, immediately repair it with:
+
+```bash
+gh pr edit --body-file /tmp/pr-body.md
 ```
 
 # Example
@@ -140,15 +164,16 @@ gh pr create
 
 # Create with title and body
 gh pr create --title "Add X" --body "Description here"
+gh pr create --title "Add X" --body-file /tmp/pr-body.md
 
 # Create as draft
-gh pr create --draft --title "Add X" --body "..."
+gh pr create --draft --title "Add X" --body-file /tmp/pr-body.md
 
-# Create with specific base branch
-gh pr create --base develop --title "Add X" --body "..."
+# Create with detected default base branch
+gh pr create --base "$BASE_REF" --title "Add X" --body-file /tmp/pr-body.md
 
 # Create and immediately open in browser
-gh pr create --title "Add X" --body "..." --web
+gh pr create --title "Add X" --body-file /tmp/pr-body.md --web
 ```
 
 # Validation Checklist
@@ -160,3 +185,5 @@ Before creating the PR, verify:
 - [ ] All relevant links are included
 - [ ] No AI/Claude attribution anywhere
 - [ ] No Co-Authored-By headers in commits
+- [ ] Base branch was detected dynamically instead of assuming `main`
+- [ ] Created PR body was verified with `gh pr view`

--- a/templates/pi/skills/creating-pull-requests/SKILL.md
+++ b/templates/pi/skills/creating-pull-requests/SKILL.md
@@ -56,11 +56,18 @@ Common verbs: Add, Fix, Update, Remove, Refactor, Implement, Improve, Replace, E
 
 ### 1. Gather context
 
+Determine the default branch dynamically instead of assuming `main`:
+
 ```bash
-git log main..HEAD --oneline   # commits on this branch
-git diff main...HEAD           # full diff
-git branch --show-current      # current branch name
+git symbolic-ref --quiet --short refs/remotes/origin/HEAD   # e.g. origin/main or origin/master
+BASE_REF=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##')
+git log "origin/$BASE_REF"..HEAD --oneline                 # commits on this branch
+git diff "origin/$BASE_REF"...HEAD                         # full diff
+git merge-base HEAD "origin/$BASE_REF"                     # merge base for precise comparisons
+git branch --show-current                                   # current branch name
 ```
+
+If `origin/HEAD` is unavailable, inspect `git remote show origin` and use the reported HEAD branch.
 
 ### 2. Identify links and references
 
@@ -71,8 +78,10 @@ Look in commit messages and the branch name for:
 
 ### 3. Draft and create the PR
 
+Prefer `--body-file` or a single-quoted heredoc saved to a temp file. This avoids shell interpolation bugs with backticks and inline code spans.
+
 ```bash
-gh pr create --title "Add feature X" --body "$(cat <<'EOF'
+cat > /tmp/pr-body.md <<'EOF'
 ## Why
 
 [Motivation here]
@@ -89,7 +98,20 @@ gh pr create --title "Add feature X" --body "$(cat <<'EOF'
 
 - [Ticket](url)
 EOF
-)"
+
+gh pr create --base "$BASE_REF" --title "Add feature X" --body-file /tmp/pr-body.md
+```
+
+After creation, verify what GitHub received:
+
+```bash
+gh pr view --json title,body,url
+```
+
+If formatting was mangled, immediately repair it with:
+
+```bash
+gh pr edit --body-file /tmp/pr-body.md
 ```
 
 ## Example
@@ -129,7 +151,8 @@ waits `2^attempt * 100ms + random(0-50ms)` before retrying. Logs each retry for 
 gh pr create                                    # fully interactive
 gh pr create --fill                             # title + body from commit messages
 gh pr create --draft                            # open as draft
-gh pr create --base develop                     # target a non-default base branch
+gh pr create --base "$BASE_REF"                # target the detected default base branch
+gh pr create --body-file /tmp/pr-body.md        # safest for markdown with backticks/code spans
 gh pr create --reviewer alice,bob
 gh pr create --label bug --assignee "@me"
 gh pr create --web                              # finish in the browser
@@ -142,4 +165,6 @@ gh pr create --web                              # finish in the browser
 - [ ] All relevant links are included
 - [ ] No AI/Claude attribution anywhere in the PR or commits
 - [ ] No `Co-Authored-By` headers in commits
+- [ ] Base branch was detected dynamically instead of assuming `main`
+- [ ] Created PR body was verified with `gh pr view`
 {% endraw %}

--- a/templates/pi/skills/gh-cli/SKILL.md
+++ b/templates/pi/skills/gh-cli/SKILL.md
@@ -13,8 +13,9 @@ description: Work with GitHub using the gh CLI. Use this skill for pull requests
 gh pr create                                      # interactive prompt
 gh pr create --fill                               # title + body from commit messages
 gh pr create --title "Fix bug" --body "Details"
+gh pr create --title "Fix bug" --body-file /tmp/pr-body.md
 gh pr create --draft
-gh pr create --base main --reviewer alice,bob
+gh pr create --base "$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##')" --reviewer alice,bob
 gh pr create --label bug --assignee "@me"
 ```
 
@@ -66,6 +67,7 @@ gh pr merge 123 --auto --squash     # auto-merge when checks pass
 
 ```bash
 gh pr edit 123 --title "New title" --body "New body"
+gh pr edit 123 --body-file /tmp/pr-body.md
 gh pr edit 123 --add-label bug --remove-label wip
 gh pr edit 123 --add-reviewer alice --add-assignee "@me"
 gh pr ready 123                     # mark draft as ready for review
@@ -212,6 +214,9 @@ gh issue list --assignee "@me" --json number,title,labels \
 
 - Most commands default to the current repo; use `-R owner/repo` to target another.
 - Use `@me` as a shorthand for your own GitHub username in filters.
+- Prefer `--body-file` over `--body` for PR descriptions containing markdown code spans or backticks.
+- Detect the default branch dynamically with `git symbolic-ref --quiet --short refs/remotes/origin/HEAD` instead of assuming `main`.
+- After `gh pr create`, verify the rendered PR body with `gh pr view --json title,body,url`.
 - `--web` on almost any command opens the relevant GitHub page in the browser.
 - `GH_REPO=owner/repo gh ...` sets the repo for a single command without `-R`.
 - `gh status` gives a cross-repo overview of your open PRs, review requests, and mentions.

--- a/templates/zed/keymap.json
+++ b/templates/zed/keymap.json
@@ -2,7 +2,6 @@
 [
   {
     "bindings": {
-      "ctrl-shift-o": ["agent::NewExternalAgentThread", { "agent": "codex" }],
       "ctrl-tab": "pane::ActivatePreviousItem",
       "ctrl-shift-tab": "pane::ActivateNextItem"
     }


### PR DESCRIPTION
## Why

This branch updates local development tooling and fixes agent-related configuration and documentation issues uncovered while using the repo.

## Approach

Apply the environment and editor config changes in the Ansible-managed templates, then update the skill templates so future PR creation uses safer defaults and more accurate Git/GitHub guidance.

## How it works

- adds `worktrunk` to the installed package list in `site.yml`
- adds `node = "25"` to `templates/mise.toml`
- removes the invalid `ctrl-shift-o` Codex thread binding from `templates/zed/keymap.json`
- updates the pi and opencode PR skills to detect the default branch dynamically instead of assuming `main`
- updates PR creation guidance to prefer `gh pr create --body-file`, verify PR bodies after creation, and repair them with `gh pr edit --body-file` when needed
- updates the pi GitHub CLI skill with safer `gh pr create` and `gh pr edit` examples

## Links

- None