### PR TITLE
Add 8px window padding in kitty

### DIFF
--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -19,6 +19,12 @@ font_size 13
 
 
 # --------------------
+# Window padding
+# --------------------
+window_padding_width 8
+
+
+# --------------------
 # Color scheme (One Dark)
 # --------------------
 foreground              #abb2bf


### PR DESCRIPTION
## Why

Kitty windows are flush against the edge of the terminal, which makes the layout feel cramped.
Adding a small amount of padding improves readability and gives panes a bit more breathing room.

## Approach

Use Kitty's built-in `window_padding_width` setting instead of introducing any theme-specific or per-layout customization. This keeps the change small, predictable, and easy to adjust later.

## How it works

- sets `window_padding_width 8` in `templates/kitty.conf`
- applies the padding globally to Kitty windows managed from this dotfiles repo

## Links

- PR #35
