### PR TITLE
Format site.yml copy entries and add Pi AGENTS.md

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 120

--- a/site.yml
+++ b/site.yml
@@ -86,134 +86,93 @@
         cp_entity_name: "{{ item.name }}"
         cp_entity_permissions: "0600"
       loop:
-        - {
-            name: "Wez terminal config",
-            src: "./templates/wezterm.lua.j2",
-            dest: "~/.config/wezterm/wezterm.lua",
-          }
-        - { name: "Zsh config", src: "./templates/zshrc.sh", dest: "~/.zshrc" }
-        - {
-            name: "Zed config",
-            src: "./templates/zed/settings.json",
-            dest: "~/.config/zed/settings.json",
-          }
-        - {
-            name: "Zed keymap",
-            src: "./templates/zed/keymap.json",
-            dest: "~/.config/zed/keymap.json",
-          }
-        - { name: "Vim config", src: "./templates/vimrc", dest: "~/.vimrc" }
-        - {
-            name: "Midnight commander INI config",
-            src: "./templates/mc.ini",
-            dest: "~/.config/mc/ini",
-          }
-        - { name: "Kitty config", src: "./templates/kitty.conf", dest: "~/.config/kitty/kitty.conf" }
-        - {
-            name: "Gemini config",
-            src: "./templates/geminiSettings.json",
-            dest: "~/.gemini/settings.json",
-          }
-        - {
-            name: "OpenCode config",
-            src: "./templates/opencode/opencode.json",
-            dest: "~/.config/opencode/opencode.json",
-          }
-        - {
-            name: "OpenCode skill: Email draft polish",
-            src: "./templates/opencode/skills/email-draft-polish/SKILL.md",
-            dest: "~/.config/opencode/skills/email-draft-polish/SKILL.md",
-          }
-        - {
-            name: "OpenCode skill: Create plan",
-            src: "./templates/opencode/skills/create-plan/SKILL.md",
-            dest: "~/.config/opencode/skills/create-plan/SKILL.md",
-          }
-        - {
-            name: "OpenCode skill: Reviewing code",
-            src: "./templates/opencode/skills/reviewing-code/SKILL.md",
-            dest: "~/.config/opencode/skills/reviewing-code/SKILL.md",
-          }
-        - {
-            name: "OpenCode skill: Reviewing code checklist",
-            src: "./templates/opencode/skills/reviewing-code/review-checklist.md",
-            dest: "~/.config/opencode/skills/reviewing-code/review-checklist.md",
-          }
-        - {
-            name: "OpenCode skill: Creating pull requests",
-            src: "./templates/opencode/skills/creating-pull-requests/SKILL.md",
-            dest: "~/.config/opencode/skills/creating-pull-requests/SKILL.md",
-          }
-        - {
-            name: "OpenCode skill: Fix gh CI",
-            src: "./templates/opencode/skills/gh-fix-ci/SKILL.md",
-            dest: "~/.config/opencode/skills/gh-fix-ci/SKILL.md",
-          }
-        - {
-            name: "OpenCode skill: Fix gh CI script",
-            src: "./templates/opencode/skills/gh-fix-ci/scripts/inspect_pr_checks.py",
-            dest: "~/.config/opencode/skills/gh-fix-ci/scripts/inspect_pr_checks.py",
-          }
-        - {
-            name: "OpenCode skill: Developer growth analysis",
-            src: "./templates/opencode/skills/developer-growth-analysis/SKILL.md",
-            dest: "~/.config/opencode/skills/developer-growth-analysis/SKILL.md",
-          }
-        - {
-            name: "Codex rules: Git",
-            src: "./templates/codex/rules/git.rules",
-            dest: "~/.codex/rules/git.rules",
-          }
-        - {
-            name: "Codex rules: Helm",
-            src: "./templates/codex/rules/helm.rules",
-            dest: "~/.codex/rules/helm.rules",
-          }
-        - {
-            name: "Codex rules: GitHub CLI",
-            src: "./templates/codex/rules/gh.rules",
-            dest: "~/.codex/rules/gh.rules",
-          }
-        - {
-            name: "Codex rules: NPM",
-            src: "./templates/codex/rules/npm.rules",
-            dest: "~/.codex/rules/npm.rules",
-          }
-        - {
-            name: "Firefox user.js",
-            src: "./templates/firefox/user.js",
-            dest: "{{ firefox_profile_dir }}/user.js"
-          }
-        - {
-            name: "Starship config",
-            src: "./templates/starship.toml",
-            dest: "~/.config/starship.toml"
-          }
-        - {
-            name: "Mise config",
-            src: "./templates/mise.toml",
-            dest: "~/.config/mise/config.toml"
-          }
-        - {
-            name: "Pi skill: worktrunk",
-            src: "./templates/pi/skills/worktrunk/SKILL.md",
-            dest: "~/.pi/agent/skills/worktrunk/SKILL.md",
-          }
-        - {
-            name: "Pi skill: gh-cli",
-            src: "./templates/pi/skills/gh-cli/SKILL.md",
-            dest: "~/.pi/agent/skills/gh-cli/SKILL.md",
-          }
-        - {
-            name: "Pi skill: creating-pull-requests",
-            src: "./templates/pi/skills/creating-pull-requests/SKILL.md",
-            dest: "~/.pi/agent/skills/creating-pull-requests/SKILL.md",
-          }
-        - {
-            name: "Pi skill: ansible",
-            src: "./templates/pi/skills/ansible/SKILL.md",
-            dest: "~/.pi/agent/skills/ansible/SKILL.md",
-          }
+        - name: "Wez terminal config"
+          src: "./templates/wezterm.lua.j2"
+          dest: "~/.config/wezterm/wezterm.lua"
+        - name: "Zsh config"
+          src: "./templates/zshrc.sh"
+          dest: "~/.zshrc"
+        - name: "Zed config"
+          src: "./templates/zed/settings.json"
+          dest: "~/.config/zed/settings.json"
+        - name: "Zed keymap"
+          src: "./templates/zed/keymap.json"
+          dest: "~/.config/zed/keymap.json"
+        - name: "Vim config"
+          src: "./templates/vimrc"
+          dest: "~/.vimrc"
+        - name: "Midnight commander INI config"
+          src: "./templates/mc.ini"
+          dest: "~/.config/mc/ini"
+        - name: "Kitty config"
+          src: "./templates/kitty.conf"
+          dest: "~/.config/kitty/kitty.conf"
+        - name: "Gemini config"
+          src: "./templates/geminiSettings.json"
+          dest: "~/.gemini/settings.json"
+        - name: "OpenCode config"
+          src: "./templates/opencode/opencode.json"
+          dest: "~/.config/opencode/opencode.json"
+        - name: "OpenCode skill: Email draft polish"
+          src: "./templates/opencode/skills/email-draft-polish/SKILL.md"
+          dest: "~/.config/opencode/skills/email-draft-polish/SKILL.md"
+        - name: "OpenCode skill: Create plan"
+          src: "./templates/opencode/skills/create-plan/SKILL.md"
+          dest: "~/.config/opencode/skills/create-plan/SKILL.md"
+        - name: "OpenCode skill: Reviewing code"
+          src: "./templates/opencode/skills/reviewing-code/SKILL.md"
+          dest: "~/.config/opencode/skills/reviewing-code/SKILL.md"
+        - name: "OpenCode skill: Reviewing code checklist"
+          src: "./templates/opencode/skills/reviewing-code/review-checklist.md"
+          dest: "~/.config/opencode/skills/reviewing-code/review-checklist.md"
+        - name: "OpenCode skill: Creating pull requests"
+          src: "./templates/opencode/skills/creating-pull-requests/SKILL.md"
+          dest: "~/.config/opencode/skills/creating-pull-requests/SKILL.md"
+        - name: "OpenCode skill: Fix gh CI"
+          src: "./templates/opencode/skills/gh-fix-ci/SKILL.md"
+          dest: "~/.config/opencode/skills/gh-fix-ci/SKILL.md"
+        - name: "OpenCode skill: Fix gh CI script"
+          src: "./templates/opencode/skills/gh-fix-ci/scripts/inspect_pr_checks.py"
+          dest: "~/.config/opencode/skills/gh-fix-ci/scripts/inspect_pr_checks.py"
+        - name: "OpenCode skill: Developer growth analysis"
+          src: "./templates/opencode/skills/developer-growth-analysis/SKILL.md"
+          dest: "~/.config/opencode/skills/developer-growth-analysis/SKILL.md"
+        - name: "Codex rules: Git"
+          src: "./templates/codex/rules/git.rules"
+          dest: "~/.codex/rules/git.rules"
+        - name: "Codex rules: Helm"
+          src: "./templates/codex/rules/helm.rules"
+          dest: "~/.codex/rules/helm.rules"
+        - name: "Codex rules: GitHub CLI"
+          src: "./templates/codex/rules/gh.rules"
+          dest: "~/.codex/rules/gh.rules"
+        - name: "Codex rules: NPM"
+          src: "./templates/codex/rules/npm.rules"
+          dest: "~/.codex/rules/npm.rules"
+        - name: "Firefox user.js"
+          src: "./templates/firefox/user.js"
+          dest: "{{ firefox_profile_dir }}/user.js"
+        - name: "Starship config"
+          src: "./templates/starship.toml"
+          dest: "~/.config/starship.toml"
+        - name: "Mise config"
+          src: "./templates/mise.toml"
+          dest: "~/.config/mise/config.toml"
+        - name: "Pi skill: worktrunk"
+          src: "./templates/pi/skills/worktrunk/SKILL.md"
+          dest: "~/.pi/agent/skills/worktrunk/SKILL.md"
+        - name: "Pi skill: gh-cli"
+          src: "./templates/pi/skills/gh-cli/SKILL.md"
+          dest: "~/.pi/agent/skills/gh-cli/SKILL.md"
+        - name: "Pi skill: creating-pull-requests"
+          src: "./templates/pi/skills/creating-pull-requests/SKILL.md"
+          dest: "~/.pi/agent/skills/creating-pull-requests/SKILL.md"
+        - name: "Pi skill: ansible"
+          src: "./templates/pi/skills/ansible/SKILL.md"
+          dest: "~/.pi/agent/skills/ansible/SKILL.md"
+        - name: "Pi global AGENTS.md"
+          src: "./templates/pi/AGENTS.md"
+          dest: "~/.pi/agent/AGENTS.md"
 
 
     - name: "Create mise conf.d directory"

--- a/templates/pi/AGENTS.md
+++ b/templates/pi/AGENTS.md
@@ -1,0 +1,10 @@
+# Global Agent Rules
+
+## Worktree Policy
+
+Before making any code or config changes in a git repository:
+1. Check existing worktrees with `wt list` to see if a relevant branch already exists.
+2. If yes — switch to it.
+3. If no — create a new worktree with `wt switch --create <branch-name>`.
+
+Never commit or make changes directly on the default branch (main, master, develop, etc.).


### PR DESCRIPTION
## Why

The `site.yml` copy loop was hard to scan and inconsistent because most entries were written inline. In addition, the Pi global `AGENTS.md` file was not being deployed by the dotfiles playbook.

## Approach

Convert the long inline object list into standard multi-line YAML mappings so the playbook is easier to read and maintain. Add the new Pi global agent rules file as another copied template in the same loop.

## How it works

- adds a `.yamllint` config with a 120-character line limit
- reformats the `site.yml` copy task loop into multi-line `name` / `src` / `dest` mappings
- adds `templates/pi/AGENTS.md`
- copies that file to `~/.pi/agent/AGENTS.md` through the existing config deployment task

## Links

- PR #36
