### PR TITLE
Add Pi agent config updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # mise config is gitignored globally. This line is to ungitignore it for this very repo
 !templates/mise.toml
+# AGENTS.md is gitignored globally; un-ignore it for this repo
+!templates/pi/AGENTS.md
 *env*
 !sample.env
 id_ed*

--- a/templates/pi/AGENTS.md
+++ b/templates/pi/AGENTS.md
@@ -8,3 +8,47 @@ Before making any code or config changes in a git repository:
 3. If no — create a new worktree with `wt switch --create <branch-name>`.
 
 Never commit or make changes directly on the default branch (main, master, develop, etc.).
+
+## Commit Message Convention
+
+Always use **Conventional Commits** format for all commit messages:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type       | When to use                                         |
+|------------|-----------------------------------------------------|
+| `feat`     | A new feature                                       |
+| `fix`      | A bug fix                                           |
+| `refactor` | Code change that is neither a bug fix nor a feature |
+| `chore`    | Maintenance tasks, dependency updates, tooling      |
+| `docs`     | Documentation only changes                          |
+| `test`     | Adding or updating tests                            |
+| `ci`       | CI/CD configuration changes                         |
+| `perf`     | Performance improvements                            |
+| `style`    | Formatting, whitespace (no logic change)            |
+| `revert`   | Reverts a previous commit                           |
+
+### Rules
+
+- Description is lowercase, imperative mood, no trailing period
+- Use a scope in parentheses when it adds clarity: `feat(auth): add OAuth2 support`
+- Breaking changes: append `!` after type/scope and add `BREAKING CHANGE:` footer
+- If tied to a ticket, add it in the footer: `Refs: ENC-123`
+
+### Examples
+
+```
+feat(auth): add OAuth2 login support
+fix(cache): prevent stale entries after TTL expiry
+chore: upgrade dependencies to latest
+docs: update README with setup instructions
+refactor(api): extract retry logic into separate module
+```

--- a/templates/pi/skills/creating-pull-requests/SKILL.md
+++ b/templates/pi/skills/creating-pull-requests/SKILL.md
@@ -14,6 +14,7 @@ Create well-structured pull requests with clear titles and comprehensive descrip
 - Do NOT add yourself as a coauthor on commits (no `Co-Authored-By` headers)
 - Do NOT include phrases like "Generated with Claude" or "Created by AI"
 - Do NOT mention AI or Claude anywhere in commits or PR descriptions
+- Do NOT create a ready-for-review PR unless the user explicitly asks for it — **always use `--draft` by default**
 
 ## PR Title Format
 
@@ -181,6 +182,7 @@ gh pr create --web                              # finish in the browser
 - [ ] All relevant links are included
 - [ ] No AI/Claude attribution anywhere in the PR or commits
 - [ ] No `Co-Authored-By` headers in commits
+- [ ] PR was opened as `--draft` (unless user explicitly requested ready-for-review)
 - [ ] Base branch was detected dynamically instead of assuming `main`
 - [ ] Created PR body was verified with `gh pr view`
 {% endraw %}


### PR DESCRIPTION
## Why

Pi's global agent configuration was missing a checked-in `AGENTS.md`, and the repository did not yet enforce two workflow expectations in the shipped agent guidance: using Conventional Commits and defaulting new pull requests to draft status.

## Approach

Add the global Pi agent rules file to the repo, make sure the Ansible playbook deploys it, and update the pull request skill guidance so the default behavior matches the desired workflow.

## How it works

- un-ignores `templates/pi/AGENTS.md` in `.gitignore`
- adds `templates/pi/AGENTS.md` with worktree and Conventional Commits guidance
- updates `site.yml` to copy that file to `~/.pi/agent/AGENTS.md`
- updates the creating-pull-requests skill to require `--draft` by default unless the user asks for a ready-for-review PR

## Links

- Branch: `feat/agent-config-updates`
