### PR TITLE
docs(agents): promote never-commit-to-default-branch rule to global t…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,5 @@
 # Agent Guidelines
 
-## Git Workflow — MANDATORY
-
-**Never commit directly to the default branch (`master`/`main`) unless the user explicitly says so.**
-
-Always follow this workflow:
-1. Create a new branch/worktree: `wt switch --create <branch-name>`
-2. Make changes in that worktree
-3. Commit and push from the feature branch
-4. Merge via `wt merge` (or open a PR)
-
-The only exception is when the user explicitly says something like *"commit directly to main"* or *"skip the branch"*.
-
----
-
 # Gemini Code Assistant Project Overview
 
 This project uses Ansible to automate the setup and configuration of a development environment on macOS. It installs various tools and applications, and deploys configuration files for them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# Agent Guidelines
+
+# Claude Code Project Overview
+
+This project uses Ansible to automate the setup and configuration of a development environment on macOS. It installs tools and applications via Homebrew and deploys configuration files.
+
+## Project Structure
+
+- `site.yml`: The main Ansible playbook.
+- `ansible.cfg`: Ansible configuration (sets inventory path, roles path, etc.).
+- `inventory.yml`: Inventory file with two hosts — `home` and `work` — both targeting `localhost`.
+- `roles/`: Contains Ansible roles.
+  - `cp`: A role for copying/templating config files to the target machine.
+- `group_vars/`: Variables shared across all hosts (`all.yml`) and host-specific overrides (`home.yml`, `work.yml`).
+- `host_vars/`: Additional per-host variable files.
+- `templates/`: Jinja2 templates for configuration files (e.g., `wezterm.lua.j2`, `vimrc`).
+- `README.md`: Project README.
+
+## How to Use
+
+The inventory is already committed. Since both `home` and `work` target `localhost`, always pass `--limit` to avoid running tasks against both entries at once.
+
+**Run the full playbook:**
+
+```bash
+ansible-playbook site.yml --limit home
+# or
+ansible-playbook site.yml --limit work
+```
+
+### Running Specific Tasks
+
+Use `--tags` to run only a subset of tasks:
+
+- `configs`: Copies configuration files and generates shell integrations.
+
+```bash
+ansible-playbook site.yml --limit home --tags configs
+```

--- a/templates/pi/AGENTS.md
+++ b/templates/pi/AGENTS.md
@@ -1,13 +1,17 @@
 # Global Agent Rules
 
-## Worktree Policy
+## Worktree Policy — MANDATORY
 
-Before making any code or config changes in a git repository:
+**Never commit directly to the default branch (`master`/`main`) unless the user explicitly says so.**
+
+Always follow this workflow:
 1. Check existing worktrees with `wt list` to see if a relevant branch already exists.
 2. If yes — switch to it.
 3. If no — create a new worktree with `wt switch --create <branch-name>`.
+4. Make changes in that worktree, commit and push from the feature branch.
+5. Merge via `wt merge` (or open a PR).
 
-Never commit or make changes directly on the default branch (main, master, develop, etc.).
+The only exception is when the user explicitly says something like *"commit directly to main"* or *"skip the branch"*.
 
 ## Commit Message Convention
 


### PR DESCRIPTION
…emplate

Move the MANDATORY worktree policy from the repo-local AGENTS.md into templates/pi/AGENTS.md so it is deployed globally to ~/.pi/agent/AGENTS.md. Remove the now-redundant Git Workflow section from the repo-level AGENTS.md.