### PR TITLE
Document 1Password bootstrap requirement and improve git task names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Bootstrap requirement
+
+`op` (the 1Password CLI) must already be installed and signed in before you bootstrap this machine. The playbook uses it to read the Ansible vault password during setup, so bootstrapping will fail if the CLI is unavailable.
+
 Because both inventory entries target `localhost`, you should limit each run to the laptop you are currently on. This ensures Ansible loads the correct host-specific variables:
 
 ```bash

--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-git_global_excludesfile: "{{ ansible_env.HOME }}/.gitignore_global"
+git_global_excludesfile: "{{ ansible_facts['env']['HOME'] }}/.gitignore_global"
 git_global_ignore_entries:
   - "PLAN.md"
   - ".idea"

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -15,20 +15,20 @@
       - git_user_email | string | length > 0
     fail_msg: git_user_name and git_user_email must be set before configuring global Git identity
 
-- name: Ensure global gitignore file exists
+- name: "Ensure global gitignore file exists: {{ git_global_excludesfile }}"
   ansible.builtin.file:
     path: "{{ git_global_excludesfile }}"
     state: touch
     mode: '0600'
 
-- name: Ensure global gitignore entries are present
+- name: "Ensure global gitignore entries are present: {{ git_global_excludesfile }}"
   ansible.builtin.lineinfile:
     path: "{{ git_global_excludesfile }}"
     line: "{{ item }}"
     state: present
   loop: "{{ git_global_ignore_entries }}"
 
-- name: Configure Git global excludes file
+- name: "Configure Git global excludes file: {{ git_global_excludesfile }}"
   community.general.git_config:
     name: core.excludesfile
     scope: global

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -6,7 +6,7 @@
       - ansible_user | string | length > 0
     fail_msg: ansible_user must be set before configuring global Git settings
 
-- name: Ensure Git identity is set
+- name: "Ensure Git identity is set: {{ git_user_name }} <{{ git_user_email }}>"
   ansible.builtin.assert:
     that:
       - git_user_name is defined
@@ -34,13 +34,13 @@
     scope: global
     value: "{{ git_global_excludesfile }}"
 
-- name: Configure Git user name
+- name: "Configure Git user name: {{ git_user_name }}"
   community.general.git_config:
     name: user.name
     scope: global
     value: "{{ git_user_name }}"
 
-- name: Configure Git user email
+- name: "Configure Git user email: {{ git_user_email }}"
   community.general.git_config:
     name: user.email
     scope: global


### PR DESCRIPTION
## Why

Bootstrapping depends on the 1Password CLI being available so Ansible can read the vault password during setup. The repository also included git role paths and task names that were less robust and less informative than they could be.

## Approach

Document the 1Password CLI requirement directly in the README where bootstrap instructions already live, switch the git role default to the Ansible facts-based environment lookup, and make the git tasks include the concrete values they operate on in their task names.

## How it works

- adds a bootstrap requirement section to `README.md` explaining that `op` must be installed and signed in before running the playbook
- changes `git_global_excludesfile` in `roles/git/defaults/main.yml` to use `ansible_facts['env']['HOME']`
- updates `roles/git/tasks/main.yml` so git-related task names show the resolved excludes file path, user name, and email address where those values are used

## Links

- Ref: `d780ef34-bd94-4365-a732-b0e71d33133a`
