### PR TITLE
Manage ansible via mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-## Bootstrap requirement
+˚## Bootstrap requirements
 
-`op` (the 1Password CLI) must already be installed and signed in before you bootstrap this machine. The playbook uses it to read the Ansible vault password during setup, so bootstrapping will fail if the CLI is unavailable.
+Before you bootstrap this machine, make sure these tools are already available:
+
+- `mise`, installed manually first, because this repository uses it to manage the preferred `ansible` installation and does not bootstrap `mise` for you.
+- `ansible`, installed through `mise`.
+- `op` (the 1Password CLI), installed and signed in, because the playbook uses it to read the Ansible vault password.
+
+For example:
+
+```bash
+mise use -g pipx:ansible
+brew install 1password-cli
+```
+
+Bootstrapping will fail if any prerequisite is unavailable.
 
 Because both inventory entries target `localhost`, you should limit each run to the laptop you are currently on. This ensures Ansible loads the correct host-specific variables:
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Before you bootstrap this machine, make sure these tools are already available:
 
 - `mise`, installed manually first, because this repository uses it to manage the preferred `ansible` installation and does not bootstrap `mise` for you.
 - `ansible`, installed through `mise`.
+- `ansible-lint`, installed through `mise`.
 - `op` (the 1Password CLI), installed and signed in, because the playbook uses it to read the Ansible vault password.
 
 For example:
 
 ```bash
 mise use -g pipx:ansible
+mise use -g pipx:ansible-lint
 brew install 1password-cli
 ```
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -11,7 +11,6 @@ homebrew_packages:
   - ack
   - act
   - anomalyco/tap/opencode
-  - ansible
   - ansible-lint
   - 1password-cli
   - bat

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -11,7 +11,6 @@ homebrew_packages:
   - ack
   - act
   - anomalyco/tap/opencode
-  - ansible-lint
   - 1password-cli
   - bat
   - btop

--- a/templates/mise.toml
+++ b/templates/mise.toml
@@ -2,5 +2,6 @@
 _.path = "/Applications/IntelliJ IDEA.app/Contents/MacOS"
 
 [tools]
+ansible = "pipx:ansible"
 node = "25"
 pi = "latest"

--- a/templates/mise.toml
+++ b/templates/mise.toml
@@ -3,5 +3,6 @@ _.path = "/Applications/IntelliJ IDEA.app/Contents/MacOS"
 
 [tools]
 ansible = "pipx:ansible"
+ansible-lint = "pipx:ansible-lint"
 node = "25"
 pi = "latest"


### PR DESCRIPTION
## Why

The bootstrap flow should match how this machine is actually set up. `ansible` and `ansible-lint` are now managed through `mise`, while `mise` itself must already be installed before the playbook can run.

## Approach

Remove the Homebrew-managed `ansible` and `ansible-lint` packages, add both tools to the shared `mise` tool config, and update the bootstrap documentation to spell out the manual prerequisites.

## How it works

- removes `ansible` and `ansible-lint` from `homebrew_packages`
- adds `ansible = "pipx:ansible"` to `templates/mise.toml`
- adds `ansible-lint = "pipx:ansible-lint"` to `templates/mise.toml`
- updates `README.md` to document that `mise` must be installed manually first
- documents installing `ansible` and `ansible-lint` with `mise` before bootstrap
- documents installing `1password-cli` with Homebrew before bootstrap

## Links

- None
