### PR TITLE
Add pi_agent role to configure Pi agent

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,2 +1,3 @@
 inventory.yml
 CLAUDE.local.md
+tmp

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -154,15 +154,15 @@ config_files:
 
 pi_agent_settings_path: "~/.pi/agent/settings.json"
 
+pi_agent_settings_packages:
+  - "npm:@fink-andreas/pi-linear-tools"
+  - "npm:pi-subagents"
+  - "npm:pi-mono-ask-user-question"
+  - "npm:@plannotator/pi-extension"
+  - "git:github.com/boga/pi-local-claude-loader"
+
 pi_agent_settings_overrides: |-
   {
     "collapseChangelog": true,
-    "enableInstallTelemetry": false,
-    "packages": [
-      "npm:@fink-andreas/pi-linear-tools",
-      "npm:pi-subagents",
-      "npm:pi-mono-ask-user-question",
-      "npm:@plannotator/pi-extension",
-      "git:github.com/boga/pi-local-claude-loader"
-    ]
+    "enableInstallTelemetry": false
   }

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -153,16 +153,13 @@ config_files:
     dest: "~/.pi/agent/AGENTS.md"
 
 pi_agent_settings_path: "~/.pi/agent/settings.json"
-
-pi_agent_settings_packages:
-  - "npm:@fink-andreas/pi-linear-tools"
-  - "npm:pi-subagents"
-  - "npm:pi-mono-ask-user-question"
-  - "npm:@plannotator/pi-extension"
-  - "git:github.com/boga/pi-local-claude-loader"
-
 pi_agent_settings_overrides: |-
   {
     "collapseChangelog": true,
     "enableInstallTelemetry": false
   }
+pi_agent_settings_packages:
+  - "git:github.com/boga/pi-local-claude-loader"
+  - "npm:@plannotator/pi-extension"
+  - "npm:pi-mono-ask-user-question"
+  - "npm:pi-subagents"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -151,3 +151,18 @@ config_files:
   - name: "Pi global AGENTS.md"
     src: "./templates/pi/AGENTS.md"
     dest: "~/.pi/agent/AGENTS.md"
+
+pi_agent_settings_path: "~/.pi/agent/settings.json"
+
+pi_agent_settings_overrides: |-
+  {
+    "collapseChangelog": true,
+    "enableInstallTelemetry": false,
+    "packages": [
+      "npm:@fink-andreas/pi-linear-tools",
+      "npm:pi-subagents",
+      "npm:pi-mono-ask-user-question",
+      "npm:@plannotator/pi-extension",
+      "git:github.com/boga/pi-local-claude-loader"
+    ]
+  }

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -3,3 +3,6 @@ ansible_user: ivan-shnurchenko
 ansible_group: staff
 ansible_python_interpreter: /opt/homebrew/bin/python3
 firefox_profile_dir: /Users/ivan-shnurchenko/Library/Application Support/Firefox/Profiles/vfxfh9r4.default-release
+
+# Add to the global packages list work-related ones
+pi_agent_settings_packages: "{{ pi_agent_settings_packages + ['npm:@fink-andreas/pi-linear-tools'] }}"

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -4,5 +4,6 @@ ansible_group: staff
 ansible_python_interpreter: /opt/homebrew/bin/python3
 firefox_profile_dir: /Users/ivan-shnurchenko/Library/Application Support/Firefox/Profiles/vfxfh9r4.default-release
 
-# Add to the global packages list work-related ones
-pi_agent_settings_packages: "{{ pi_agent_settings_packages + ['npm:@fink-andreas/pi-linear-tools'] }}"
+# Work-specific packages, appended to the global pi_agent_settings_packages list
+pi_agent_settings_extra_packages:
+  - "npm:@fink-andreas/pi-linear-tools"

--- a/roles/pi_agent/README.md
+++ b/roles/pi_agent/README.md
@@ -4,8 +4,9 @@ Installs and configures the [Pi coding agent](https://www.npmjs.com/package/@mar
 
 ## What it does
 
-1. **Installs Pi** via mise, using the version declared in `~/.config/mise/config.toml` (managed by the `cp` role from `templates/mise.toml`).
-2. **Merges desired settings** into `~/.pi/agent/settings.json` without clobbering keys the agent manages at runtime (e.g. `lastChangelogVersion`, `defaultModel`).
+1. **Merges desired settings** into `~/.pi/agent/settings.json` without clobbering keys the agent manages at runtime (e.g. `lastChangelogVersion`, `defaultModel`).
+
+Pi itself is installed via mise — the version is declared in `templates/mise.toml` (deployed by the `cp` role) and mise handles the actual installation.
 
 ## Variables
 

--- a/roles/pi_agent/README.md
+++ b/roles/pi_agent/README.md
@@ -1,0 +1,47 @@
+# pi_agent
+
+Installs and configures the [Pi coding agent](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) on macOS.
+
+## What it does
+
+1. **Installs Pi** via mise (`mise install pi`), using the version already declared in `~/.config/mise/config.toml` (managed by the `cp` role from `templates/mise.toml`).
+2. **Merges desired settings** into `~/.pi/agent/settings.json` without clobbering keys the agent manages at runtime (e.g. `lastChangelogVersion`, `defaultModel`).
+
+## Variables
+
+| Variable                      | Default                     | Description                                       |
+|-------------------------------|-----------------------------|---------------------------------------------------|
+| `pi_agent_settings_path`      | `~/.pi/agent/settings.json` | Path to the Pi agent settings file                |
+| `pi_agent_settings_overrides` | `{}` (JSON string)          | JSON string of keys to enforce in `settings.json` |
+
+`pi_agent_settings_overrides` is intentionally a **raw JSON string** (not a YAML dict) to avoid YAML↔JSON type-mapping ambiguity. The role converts it internally with `from_json` before merging.
+
+## Usage
+
+Include the role in a play and set the overrides variable in `group_vars` or `host_vars`:
+
+```yaml
+# group_vars/all.yml
+pi_agent_settings_overrides: |-
+  {
+    "collapseChangelog": true,
+    "enableInstallTelemetry": false,
+    "packages": [
+      "npm:some-extension"
+    ]
+  }
+```
+
+```yaml
+# site.yml
+- name: "Configure Pi agent"
+  tags: pi
+  ansible.builtin.include_role:
+    name: pi_agent
+```
+
+## Idempotence
+
+- The npm install task uses `state: latest`; it reports `changed` only when a newer version is available.
+- The settings merge reads the current file, applies overrides, and writes back only if the result differs from the current content. Re-running with unchanged variables reports `ok`.
+- The role bootstraps correctly on a fresh machine where `settings.json` does not yet exist.

--- a/roles/pi_agent/README.md
+++ b/roles/pi_agent/README.md
@@ -9,25 +9,25 @@ Installs and configures the [Pi coding agent](https://www.npmjs.com/package/@mar
 
 ## Variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `pi_agent_settings_path` | `~/.pi/agent/settings.json` | Path to the Pi agent settings file |
-| `pi_agent_settings_packages` | `[]` | YAML list of Pi packages to enforce. Safe to extend per-host in `host_vars` by concatenating with the group list. |
-| `pi_agent_settings_overrides` | `{}` (JSON string) | JSON string of additional keys to enforce in `settings.json`. Intentionally a raw string to avoid YAML↔JSON type-mapping ambiguity. |
+| Variable                      | Default                     | Description                                                                                                                         |
+|-------------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `pi_agent_settings_path`      | `~/.pi/agent/settings.json` | Path to the Pi agent settings file                                                                                                  |
+| `pi_agent_settings_overrides` | `{}` (JSON string)          | JSON string of additional keys to enforce in `settings.json`. Intentionally a raw string to avoid YAML↔JSON type-mapping ambiguity. |
+| `pi_agent_settings_packages`  | `[]`                        | YAML list of Pi packages to enforce. Safe to extend per-host in `host_vars` by concatenating with the group list.                   |
 
 ## Usage
 
 ```yaml
 # group_vars/all.yml
-pi_agent_settings_packages:
-  - "npm:some-extension"
-  - "npm:another-extension"
-
 pi_agent_settings_overrides: |-
   {
     "collapseChangelog": true,
     "enableInstallTelemetry": false
   }
+
+pi_agent_settings_packages:
+  - "npm:some-extension"
+  - "npm:another-extension"
 ```
 
 ```yaml

--- a/roles/pi_agent/README.md
+++ b/roles/pi_agent/README.md
@@ -14,7 +14,8 @@ Pi itself is installed via mise — the version is declared in `templates/mise.t
 |-------------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `pi_agent_settings_path`      | `~/.pi/agent/settings.json` | Path to the Pi agent settings file                                                                                                  |
 | `pi_agent_settings_overrides` | `{}` (JSON string)          | JSON string of additional keys to enforce in `settings.json`. Intentionally a raw string to avoid YAML↔JSON type-mapping ambiguity. |
-| `pi_agent_settings_packages`  | `[]`                        | YAML list of Pi packages to enforce. Safe to extend per-host in `host_vars` by concatenating with the group list.                   |
+| `pi_agent_settings_packages`  | `[]`                        | YAML list of Pi packages to enforce (group-level baseline).                                                                         |
+| `pi_agent_settings_extra_packages` | `[]`               | Host-specific packages to append to `pi_agent_settings_packages`. Define in `host_vars` to avoid self-referencing variable errors.  |
 
 ## Usage
 
@@ -33,7 +34,8 @@ pi_agent_settings_packages:
 
 ```yaml
 # host_vars/home/vars.yml — add host-specific packages without replacing the base list
-pi_agent_settings_packages: "{{ pi_agent_settings_packages + ['npm:home-only-extension'] }}"
+pi_agent_settings_extra_packages:
+  - "npm:home-only-extension"
 ```
 
 ```yaml

--- a/roles/pi_agent/README.md
+++ b/roles/pi_agent/README.md
@@ -4,44 +4,45 @@ Installs and configures the [Pi coding agent](https://www.npmjs.com/package/@mar
 
 ## What it does
 
-1. **Installs Pi** via mise (`mise install pi`), using the version already declared in `~/.config/mise/config.toml` (managed by the `cp` role from `templates/mise.toml`).
+1. **Installs Pi** via mise, using the version declared in `~/.config/mise/config.toml` (managed by the `cp` role from `templates/mise.toml`).
 2. **Merges desired settings** into `~/.pi/agent/settings.json` without clobbering keys the agent manages at runtime (e.g. `lastChangelogVersion`, `defaultModel`).
 
 ## Variables
 
-| Variable                      | Default                     | Description                                       |
-|-------------------------------|-----------------------------|---------------------------------------------------|
-| `pi_agent_settings_path`      | `~/.pi/agent/settings.json` | Path to the Pi agent settings file                |
-| `pi_agent_settings_overrides` | `{}` (JSON string)          | JSON string of keys to enforce in `settings.json` |
-
-`pi_agent_settings_overrides` is intentionally a **raw JSON string** (not a YAML dict) to avoid YAML↔JSON type-mapping ambiguity. The role converts it internally with `from_json` before merging.
+| Variable | Default | Description |
+|---|---|---|
+| `pi_agent_settings_path` | `~/.pi/agent/settings.json` | Path to the Pi agent settings file |
+| `pi_agent_settings_packages` | `[]` | YAML list of Pi packages to enforce. Safe to extend per-host in `host_vars` by concatenating with the group list. |
+| `pi_agent_settings_overrides` | `{}` (JSON string) | JSON string of additional keys to enforce in `settings.json`. Intentionally a raw string to avoid YAML↔JSON type-mapping ambiguity. |
 
 ## Usage
 
-Include the role in a play and set the overrides variable in `group_vars` or `host_vars`:
-
 ```yaml
 # group_vars/all.yml
+pi_agent_settings_packages:
+  - "npm:some-extension"
+  - "npm:another-extension"
+
 pi_agent_settings_overrides: |-
   {
     "collapseChangelog": true,
-    "enableInstallTelemetry": false,
-    "packages": [
-      "npm:some-extension"
-    ]
+    "enableInstallTelemetry": false
   }
 ```
 
 ```yaml
+# host_vars/home/vars.yml — add host-specific packages without replacing the base list
+pi_agent_settings_packages: "{{ pi_agent_settings_packages + ['npm:home-only-extension'] }}"
+```
+
+```yaml
 # site.yml
-- name: "Configure Pi agent"
-  tags: pi
+- name: "Install and configure Pi agent"
   ansible.builtin.include_role:
     name: pi_agent
 ```
 
 ## Idempotence
 
-- The npm install task uses `state: latest`; it reports `changed` only when a newer version is available.
 - The settings merge reads the current file, applies overrides, and writes back only if the result differs from the current content. Re-running with unchanged variables reports `ok`.
 - The role bootstraps correctly on a fresh machine where `settings.json` does not yet exist.

--- a/roles/pi_agent/defaults/main.yml
+++ b/roles/pi_agent/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 pi_agent_settings_path: "~/.pi/agent/settings.json"
 pi_agent_settings_packages: []
+pi_agent_settings_extra_packages: []
 pi_agent_settings_overrides: |-
   {
   }

--- a/roles/pi_agent/defaults/main.yml
+++ b/roles/pi_agent/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 pi_agent_settings_path: "~/.pi/agent/settings.json"
+pi_agent_settings_packages: []
 pi_agent_settings_overrides: |-
   {
   }

--- a/roles/pi_agent/defaults/main.yml
+++ b/roles/pi_agent/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+pi_agent_settings_path: "~/.pi/agent/settings.json"
+pi_agent_settings_overrides: |-
+  {
+  }

--- a/roles/pi_agent/tasks/main.yml
+++ b/roles/pi_agent/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: "Install Pi coding agent via mise"
-  ansible.builtin.command: mise install pi
-  changed_when: false
-
 - name: "Stat Pi agent settings.json"
   ansible.builtin.stat:
     path: "{{ pi_agent_settings_path }}"

--- a/roles/pi_agent/tasks/main.yml
+++ b/roles/pi_agent/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: "Apply Pi agent settings overrides"
   vars:
     _base: "{{ pi_settings_file.content | b64decode | from_json if pi_settings_stat.stat.exists else {} }}"
-    _overrides: "{{ pi_agent_settings_overrides | from_json | combine({'packages': pi_agent_settings_packages}) }}"
+    _overrides: "{{ pi_agent_settings_overrides | from_json | combine({'packages': pi_agent_settings_packages + pi_agent_settings_extra_packages}) }}"
   ansible.builtin.copy:
     content: "{{ _base | combine(_overrides, recursive=true) | to_nice_json }}"
     dest: "{{ pi_agent_settings_path }}"

--- a/roles/pi_agent/tasks/main.yml
+++ b/roles/pi_agent/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: "Install Pi coding agent via mise"
+  ansible.builtin.command: mise install pi
+  changed_when: false
+
+- name: "Stat Pi agent settings.json"
+  ansible.builtin.stat:
+    path: "{{ pi_agent_settings_path }}"
+  register: pi_settings_stat
+
+- name: "Read existing Pi agent settings.json"
+  ansible.builtin.slurp:
+    src: "{{ pi_agent_settings_path }}"
+  register: pi_settings_file
+  when: pi_settings_stat.stat.exists
+
+- name: "Ensure ~/.pi/agent directory exists"
+  ansible.builtin.file:
+    path: "{{ pi_agent_settings_path | dirname }}"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_group }}"
+    mode: "0755"
+
+- name: "Apply Pi agent settings overrides"
+  ansible.builtin.copy:
+    content: >-
+      {{
+        (pi_settings_file.content | b64decode | from_json
+          if pi_settings_stat.stat.exists else {})
+        | combine(pi_agent_settings_overrides | from_json, recursive=true)
+        | to_nice_json
+      }}
+    dest: "{{ pi_agent_settings_path }}"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_group }}"
+    mode: "0600"

--- a/roles/pi_agent/tasks/main.yml
+++ b/roles/pi_agent/tasks/main.yml
@@ -19,14 +19,11 @@
     mode: "0755"
 
 - name: "Apply Pi agent settings overrides"
+  vars:
+    _base: "{{ pi_settings_file.content | b64decode | from_json if pi_settings_stat.stat.exists else {} }}"
+    _overrides: "{{ pi_agent_settings_overrides | from_json | combine({'packages': pi_agent_settings_packages}) }}"
   ansible.builtin.copy:
-    content: >-
-      {{
-        (pi_settings_file.content | b64decode | from_json
-          if pi_settings_stat.stat.exists else {})
-        | combine(pi_agent_settings_overrides | from_json, recursive=true)
-        | to_nice_json
-      }}
+    content: "{{ _base | combine(_overrides, recursive=true) | to_nice_json }}"
     dest: "{{ pi_agent_settings_path }}"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_group }}"

--- a/site.yml
+++ b/site.yml
@@ -60,6 +60,6 @@
         dest: "~/.zshrc.worktrunk"
         mode: '0600'
 
-    - name: "Configure Pi agent"
+    - name: "Install and configure Pi agent"
       ansible.builtin.include_role:
         name: pi_agent

--- a/site.yml
+++ b/site.yml
@@ -59,3 +59,7 @@
         content: "{{ wt_shell_init.stdout }}\n"
         dest: "~/.zshrc.worktrunk"
         mode: '0600'
+
+    - name: "Configure Pi agent"
+      ansible.builtin.include_role:
+        name: pi_agent

--- a/templates/mise.toml
+++ b/templates/mise.toml
@@ -3,4 +3,4 @@ _.path = "/Applications/IntelliJ IDEA.app/Contents/MacOS"
 
 [tools]
 node = "25"
-pi = "latest"
+"npm:@mariozechner/pi-coding-agent" = "latest"


### PR DESCRIPTION
## Why

Configure Pi consistently through the dotfiles playbook so the agent settings and extensions are reproducible across machines without overwriting runtime-managed settings.

## Approach

Add a dedicated `pi_agent` Ansible role that merges desired settings into `~/.pi/agent/settings.json`. Keep Pi installation managed by mise via the existing `templates/mise.toml` deployment, and split shared packages from work-only extras.

## How it works

- Adds `pi_agent` defaults, tasks, and README documentation.
- Includes the role from `site.yml`.
- Updates mise to install Pi from `npm:@mariozechner/pi-coding-agent`.
- Stores shared Pi packages in `group_vars/all.yml` and work-only additions in `host_vars/work/vars.yml` through `pi_agent_settings_extra_packages`.
- Merges overrides into the current settings JSON with Ansible `slurp`, `from_json`, and `combine` so runtime-written keys are preserved.

## Links

- None