### PR TITLE
Run mise and Pi updates after playbook

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -63,3 +63,14 @@
     - name: "Install and configure Pi agent"
       ansible.builtin.include_role:
         name: pi_agent
+
+  post_tasks:
+    - name: "Upgrade mise-managed tools"
+      tags: always
+      ansible.builtin.command: mise upgrade
+      changed_when: true
+
+    - name: "Update Pi extensions"
+      tags: always
+      ansible.builtin.command: pi update --extensions
+      changed_when: true


### PR DESCRIPTION
## Why

The playbook should apply tool updates after it finishes successfully, without adding conditional handler wiring.

## Approach

Keep the change small by adding post-tasks at the end of `site.yml`.

## How it works

After the main tasks complete, the playbook runs:

- `mise upgrade`
- `pi update --extensions`

Both post-tasks use the `always` tag so they still run at the end of tagged playbook runs.

## Verification

- `ansible-playbook -i inventory.yml site.yml --limit home --syntax-check`
- `yamllint site.yml`
