### PR TITLE
Add context-mode MCP support for Pi agents

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -151,9 +151,6 @@ config_files:
   - name: "Pi global AGENTS.md"
     src: "./templates/pi/AGENTS.md"
     dest: "~/.pi/agent/AGENTS.md"
-  - name: "Pi MCP config"
-    src: "./templates/pi/mcp.json"
-    dest: "~/.pi/agent/mcp.json"
 
 pi_agent_settings_path: "~/.pi/agent/settings.json"
 pi_agent_settings_overrides: |-
@@ -161,6 +158,10 @@ pi_agent_settings_overrides: |-
     "collapseChangelog": true,
     "enableInstallTelemetry": false
   }
+pi_agent_mcp_servers:
+  context-mode:
+    command: "context-mode"
+
 pi_agent_settings_packages:
   - "git:github.com/boga/pi-local-claude-loader"
   - "npm:@plannotator/pi-extension"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -165,7 +165,7 @@ pi_agent_mcp_servers:
 pi_agent_settings_packages:
   - "git:github.com/boga/pi-local-claude-loader"
   - "npm:@plannotator/pi-extension"
+  - "npm:context-mode"
   - "npm:pi-mono-ask-user-question"
   - "npm:pi-subagents"
   - "npm:taskplane"
-  - "npm:context-mode"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -151,6 +151,9 @@ config_files:
   - name: "Pi global AGENTS.md"
     src: "./templates/pi/AGENTS.md"
     dest: "~/.pi/agent/AGENTS.md"
+  - name: "Pi MCP config"
+    src: "./templates/pi/mcp.json"
+    dest: "~/.pi/agent/mcp.json"
 
 pi_agent_settings_path: "~/.pi/agent/settings.json"
 pi_agent_settings_overrides: |-
@@ -164,3 +167,4 @@ pi_agent_settings_packages:
   - "npm:pi-mono-ask-user-question"
   - "npm:pi-subagents"
   - "npm:taskplane"
+  - "npm:context-mode"

--- a/roles/pi_agent/defaults/main.yml
+++ b/roles/pi_agent/defaults/main.yml
@@ -5,3 +5,6 @@ pi_agent_settings_extra_packages: []
 pi_agent_settings_overrides: |-
   {
   }
+
+pi_agent_mcp_path: "~/.pi/agent/mcp.json"
+pi_agent_mcp_servers: {}

--- a/roles/pi_agent/defaults/main.yml
+++ b/roles/pi_agent/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
-pi_agent_settings_path: "~/.pi/agent/settings.json"
+pi_agent_dir: "~/.pi/agent"
+pi_agent_settings_path: "{{ pi_agent_dir }}/settings.json"
 pi_agent_settings_packages: []
 pi_agent_settings_extra_packages: []
 pi_agent_settings_overrides: |-
   {
   }
 
-pi_agent_mcp_path: "~/.pi/agent/mcp.json"
+pi_agent_mcp_path: "{{ pi_agent_dir }}/mcp.json"
 pi_agent_mcp_servers: {}

--- a/roles/pi_agent/tasks/main.yml
+++ b/roles/pi_agent/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: "Ensure Pi agent directory exists"
+  ansible.builtin.file:
+    path: "{{ pi_agent_dir }}"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_group }}"
+    mode: "0755"
+
 - name: "Configure Pi agent settings"
   ansible.builtin.import_tasks: settings.yml
 

--- a/roles/pi_agent/tasks/main.yml
+++ b/roles/pi_agent/tasks/main.yml
@@ -1,30 +1,6 @@
 ---
-- name: "Stat Pi agent settings.json"
-  ansible.builtin.stat:
-    path: "{{ pi_agent_settings_path }}"
-  register: pi_settings_stat
+- name: "Configure Pi agent settings"
+  ansible.builtin.include_tasks: settings.yml
 
-- name: "Read existing Pi agent settings.json"
-  ansible.builtin.slurp:
-    src: "{{ pi_agent_settings_path }}"
-  register: pi_settings_file
-  when: pi_settings_stat.stat.exists
-
-- name: "Ensure ~/.pi/agent directory exists"
-  ansible.builtin.file:
-    path: "{{ pi_agent_settings_path | dirname }}"
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_group }}"
-    mode: "0755"
-
-- name: "Apply Pi agent settings overrides"
-  vars:
-    _base: "{{ pi_settings_file.content | b64decode | from_json if pi_settings_stat.stat.exists else {} }}"
-    _overrides: "{{ pi_agent_settings_overrides | from_json | combine({'packages': pi_agent_settings_packages + pi_agent_settings_extra_packages}) }}"
-  ansible.builtin.copy:
-    content: "{{ _base | combine(_overrides, recursive=true) | to_nice_json }}"
-    dest: "{{ pi_agent_settings_path }}"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_group }}"
-    mode: "0600"
+- name: "Configure Pi agent MCP servers"
+  ansible.builtin.include_tasks: mcp.yml

--- a/roles/pi_agent/tasks/main.yml
+++ b/roles/pi_agent/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Configure Pi agent settings"
-  ansible.builtin.include_tasks: settings.yml
+  ansible.builtin.import_tasks: settings.yml
 
 - name: "Configure Pi agent MCP servers"
-  ansible.builtin.include_tasks: mcp.yml
+  ansible.builtin.import_tasks: mcp.yml

--- a/roles/pi_agent/tasks/mcp.yml
+++ b/roles/pi_agent/tasks/mcp.yml
@@ -10,14 +10,6 @@
   register: pi_mcp_file
   when: pi_mcp_stat.stat.exists
 
-- name: "Ensure ~/.pi/agent directory exists"
-  ansible.builtin.file:
-    path: "{{ pi_agent_mcp_path | dirname }}"
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_group }}"
-    mode: "0755"
-
 - name: "Apply Pi agent MCP server config"
   vars:
     _base: "{{ pi_mcp_file.content | b64decode | from_json if pi_mcp_stat.stat.exists else {} }}"

--- a/roles/pi_agent/tasks/mcp.yml
+++ b/roles/pi_agent/tasks/mcp.yml
@@ -1,0 +1,30 @@
+---
+- name: "Stat Pi agent mcp.json"
+  ansible.builtin.stat:
+    path: "{{ pi_agent_mcp_path }}"
+  register: pi_mcp_stat
+
+- name: "Read existing Pi agent mcp.json"
+  ansible.builtin.slurp:
+    src: "{{ pi_agent_mcp_path }}"
+  register: pi_mcp_file
+  when: pi_mcp_stat.stat.exists
+
+- name: "Ensure ~/.pi/agent directory exists"
+  ansible.builtin.file:
+    path: "{{ pi_agent_mcp_path | dirname }}"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_group }}"
+    mode: "0755"
+
+- name: "Apply Pi agent MCP server config"
+  vars:
+    _base: "{{ pi_mcp_file.content | b64decode | from_json if pi_mcp_stat.stat.exists else {} }}"
+    _overrides: "{{ {'mcpServers': pi_agent_mcp_servers} }}"
+  ansible.builtin.copy:
+    content: "{{ _base | combine(_overrides, recursive=true) | to_nice_json }}"
+    dest: "{{ pi_agent_mcp_path }}"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_group }}"
+    mode: "0600"

--- a/roles/pi_agent/tasks/settings.yml
+++ b/roles/pi_agent/tasks/settings.yml
@@ -10,14 +10,6 @@
   register: pi_settings_file
   when: pi_settings_stat.stat.exists
 
-- name: "Ensure ~/.pi/agent directory exists"
-  ansible.builtin.file:
-    path: "{{ pi_agent_settings_path | dirname }}"
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_group }}"
-    mode: "0755"
-
 - name: "Apply Pi agent settings overrides"
   vars:
     _base: "{{ pi_settings_file.content | b64decode | from_json if pi_settings_stat.stat.exists else {} }}"

--- a/roles/pi_agent/tasks/settings.yml
+++ b/roles/pi_agent/tasks/settings.yml
@@ -1,0 +1,30 @@
+---
+- name: "Stat Pi agent settings.json"
+  ansible.builtin.stat:
+    path: "{{ pi_agent_settings_path }}"
+  register: pi_settings_stat
+
+- name: "Read existing Pi agent settings.json"
+  ansible.builtin.slurp:
+    src: "{{ pi_agent_settings_path }}"
+  register: pi_settings_file
+  when: pi_settings_stat.stat.exists
+
+- name: "Ensure ~/.pi/agent directory exists"
+  ansible.builtin.file:
+    path: "{{ pi_agent_settings_path | dirname }}"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_group }}"
+    mode: "0755"
+
+- name: "Apply Pi agent settings overrides"
+  vars:
+    _base: "{{ pi_settings_file.content | b64decode | from_json if pi_settings_stat.stat.exists else {} }}"
+    _overrides: "{{ pi_agent_settings_overrides | from_json | combine({'packages': pi_agent_settings_packages + pi_agent_settings_extra_packages}) }}"
+  ansible.builtin.copy:
+    content: "{{ _base | combine(_overrides, recursive=true) | to_nice_json }}"
+    dest: "{{ pi_agent_settings_path }}"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_group }}"
+    mode: "0600"

--- a/templates/mise.toml
+++ b/templates/mise.toml
@@ -4,3 +4,4 @@ _.path = "/Applications/IntelliJ IDEA.app/Contents/MacOS"
 [tools]
 node = "25"
 "npm:@mariozechner/pi-coding-agent" = "latest"
+"npm:context-mode" = "latest"

--- a/templates/pi/AGENTS.md
+++ b/templates/pi/AGENTS.md
@@ -82,7 +82,7 @@ context-mode MCP tools available. Rules protect context window from flooding. On
 
 ## Think in Code — MANDATORY
 
-Analyze/count/filter/compare/search/parse/transform data: **write code** via `ctx_execute(language, code)`, `console.log()` only the answer. Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it. Pure JavaScript — Node.js built-ins only (`fs`, `path`, `child_process`). `try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
+Analyze/compare/count/filter/parse/search/transform data: **write code** via `ctx_execute(language, code)`, `console.log()` only the answer. Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it. Pure JavaScript — Node.js built-ins only (`child_process`, `fs`, `path`). `try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
 
 ## BLOCKED — do NOT use
 
@@ -101,7 +101,7 @@ Use: `ctx_fetch_and_index(url, source)` then `ctx_search(queries)`
 ## REDIRECTED — use sandbox
 
 ### bash (>20 lines output)
-`bash` ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`, `pip install`.
+`bash` ONLY for: `cd`, `git`, `ls`, `mkdir`, `mv`, `npm install`, `pip install`, `rm`.
 Otherwise: `ctx_batch_execute(commands, queries)` or `ctx_execute(language: "shell", code: "...")`
 
 ### read (for analysis)
@@ -137,8 +137,8 @@ Session history is persistent and searchable. On resume, search BEFORE asking th
 
 | Need                    | Command                                                                   |
 |-------------------------|---------------------------------------------------------------------------|
-| What did we decide?     | `ctx_search(queries: ["decision"], source: "decision", sort: "timeline")` |
 | What constraints exist? | `ctx_search(queries: ["constraint"], source: "constraint")`               |
+| What did we decide?     | `ctx_search(queries: ["decision"], source: "decision", sort: "timeline")` |
 
 DO NOT ask "what were we working on?" — SEARCH FIRST.
 If search returns 0 results, proceed as a fresh session.
@@ -147,10 +147,10 @@ If search returns 0 results, proceed as a fresh session.
 
 | Command       | Action                                                                        |
 |---------------|-------------------------------------------------------------------------------|
-| `ctx stats`   | Call `stats` MCP tool, display full output verbatim                           |
 | `ctx doctor`  | Call `doctor` MCP tool, run returned shell command, display as checklist      |
-| `ctx upgrade` | Call `upgrade` MCP tool, run returned shell command, display as checklist     |
 | `ctx purge`   | Call `purge` MCP tool with confirm: true. Warns before wiping knowledge base. |
+| `ctx stats`   | Call `stats` MCP tool, display full output verbatim                           |
+| `ctx upgrade` | Call `upgrade` MCP tool, run returned shell command, display as checklist     |
 
 After /clear or /compact: knowledge base and session stats preserved. Use `ctx purge` to start fresh.
 

--- a/templates/pi/AGENTS.md
+++ b/templates/pi/AGENTS.md
@@ -135,22 +135,22 @@ Skills, roles, and decisions persist for the entire session. Do not abandon them
 
 Session history is persistent and searchable. On resume, search BEFORE asking the user:
 
-| Need | Command |
-|------|--------|
-| What did we decide? | `ctx_search(queries: ["decision"], source: "decision", sort: "timeline")` |
-| What constraints exist? | `ctx_search(queries: ["constraint"], source: "constraint")` |
+| Need                    | Command                                                                   |
+|-------------------------|---------------------------------------------------------------------------|
+| What did we decide?     | `ctx_search(queries: ["decision"], source: "decision", sort: "timeline")` |
+| What constraints exist? | `ctx_search(queries: ["constraint"], source: "constraint")`               |
 
 DO NOT ask "what were we working on?" — SEARCH FIRST.
 If search returns 0 results, proceed as a fresh session.
 
 ## ctx commands
 
-| Command | Action |
-|---------|--------|
-| `ctx stats` | Call `stats` MCP tool, display full output verbatim |
-| `ctx doctor` | Call `doctor` MCP tool, run returned shell command, display as checklist |
-| `ctx upgrade` | Call `upgrade` MCP tool, run returned shell command, display as checklist |
-| `ctx purge` | Call `purge` MCP tool with confirm: true. Warns before wiping knowledge base. |
+| Command       | Action                                                                        |
+|---------------|-------------------------------------------------------------------------------|
+| `ctx stats`   | Call `stats` MCP tool, display full output verbatim                           |
+| `ctx doctor`  | Call `doctor` MCP tool, run returned shell command, display as checklist      |
+| `ctx upgrade` | Call `upgrade` MCP tool, run returned shell command, display as checklist     |
+| `ctx purge`   | Call `purge` MCP tool with confirm: true. Warns before wiping knowledge base. |
 
 After /clear or /compact: knowledge base and session stats preserved. Use `ctx purge` to start fresh.
 

--- a/templates/pi/AGENTS.md
+++ b/templates/pi/AGENTS.md
@@ -74,3 +74,83 @@ When the user references a specific file (e.g. `@AGENTS.md`, `src/foo.ts`), oper
 
 Do **not** use `find` or glob patterns to discover and act on other files with the same name. If you notice other related files that might also need the same change, **ask the user first** before touching them.
 
+---
+
+# context-mode — MANDATORY routing rules
+
+context-mode MCP tools available. Rules protect context window from flooding. One unrouted command dumps 56 KB into context. Pi enforces routing via hooks (`tool_call` blocks `curl`/`wget`) AND these instructions. Hooks = hard enforcement; rules = completeness for redirections hooks cannot catch.
+
+## Think in Code — MANDATORY
+
+Analyze/count/filter/compare/search/parse/transform data: **write code** via `ctx_execute(language, code)`, `console.log()` only the answer. Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it. Pure JavaScript — Node.js built-ins only (`fs`, `path`, `child_process`). `try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
+
+## BLOCKED — do NOT use
+
+### curl / wget — FORBIDDEN (hook-enforced)
+Do NOT use `curl`/`wget` in `bash`. Pi hooks block these. Dumps raw HTTP into context.
+Use: `ctx_fetch_and_index(url, source)` or `ctx_execute(language: "javascript", code: "const r = await fetch(...)")`
+
+### Inline HTTP — FORBIDDEN
+No `node -e "fetch(...)"`, `python -c "requests.get(...)"`. Bypasses sandbox.
+Use: `ctx_execute(language, code)` — only stdout enters context
+
+### Direct web fetching — FORBIDDEN
+Raw HTML can exceed 100 KB.
+Use: `ctx_fetch_and_index(url, source)` then `ctx_search(queries)`
+
+## REDIRECTED — use sandbox
+
+### bash (>20 lines output)
+`bash` ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`, `pip install`.
+Otherwise: `ctx_batch_execute(commands, queries)` or `ctx_execute(language: "shell", code: "...")`
+
+### read (for analysis)
+Reading to **edit** → `read` correct. Reading to **analyze/explore/summarize** → `ctx_execute_file(path, language, code)`.
+
+### grep / find (large results)
+Use `ctx_execute(language: "shell", code: "grep ...")` in sandbox.
+
+## Tool selection
+
+0. **MEMORY**: `ctx_search(sort: "timeline")` — after resume, check prior context before asking user.
+1. **GATHER**: `ctx_batch_execute(commands, queries)` — runs all commands, auto-indexes, returns search. ONE call replaces 30+. Each command: `{label: "header", command: "..."}`.
+2. **FOLLOW-UP**: `ctx_search(queries: ["q1", "q2", ...])` — all questions as array, ONE call (default relevance mode).
+3. **PROCESSING**: `ctx_execute(language, code)` | `ctx_execute_file(path, language, code)` — sandbox, only stdout enters context.
+4. **WEB**: `ctx_fetch_and_index(url, source)` then `ctx_search(queries)` — raw HTML never enters context.
+5. **INDEX**: `ctx_index(content, source)` — store in FTS5 for later search.
+
+## Output
+
+Terse like caveman. Technical substance exact. Only fluff die.
+Drop: articles, filler (just/really/basically), pleasantries, hedging. Fragments OK. Short synonyms. Code unchanged.
+Pattern: [thing] [action] [reason]. [next step]. Auto-expand for: security warnings, irreversible actions, user confusion.
+Write artifacts to FILES — never inline. Return: file path + 1-line description.
+Descriptive source labels for `search(source: "label")`.
+
+## Session Continuity
+
+Skills, roles, and decisions persist for the entire session. Do not abandon them as the conversation grows.
+
+## Memory
+
+Session history is persistent and searchable. On resume, search BEFORE asking the user:
+
+| Need | Command |
+|------|--------|
+| What did we decide? | `ctx_search(queries: ["decision"], source: "decision", sort: "timeline")` |
+| What constraints exist? | `ctx_search(queries: ["constraint"], source: "constraint")` |
+
+DO NOT ask "what were we working on?" — SEARCH FIRST.
+If search returns 0 results, proceed as a fresh session.
+
+## ctx commands
+
+| Command | Action |
+|---------|--------|
+| `ctx stats` | Call `stats` MCP tool, display full output verbatim |
+| `ctx doctor` | Call `doctor` MCP tool, run returned shell command, display as checklist |
+| `ctx upgrade` | Call `upgrade` MCP tool, run returned shell command, display as checklist |
+| `ctx purge` | Call `purge` MCP tool with confirm: true. Warns before wiping knowledge base. |
+
+After /clear or /compact: knowledge base and session stats preserved. Use `ctx purge` to start fresh.
+

--- a/templates/pi/mcp.json
+++ b/templates/pi/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "context-mode": {
+      "command": "context-mode"
+    }
+  }
+}

--- a/templates/pi/mcp.json
+++ b/templates/pi/mcp.json
@@ -1,7 +1,0 @@
-{
-  "mcpServers": {
-    "context-mode": {
-      "command": "context-mode"
-    }
-  }
-}


### PR DESCRIPTION
## Why

Pi agents need context-mode available by default to route large command output, web fetches, and analysis work away from the main context window.

## Approach

Install the context-mode package through mise and Pi agent settings, configure it as an MCP server, and add global AGENTS.md routing rules that explain when to use context-mode tools instead of raw shell, HTTP, or file-reading workflows.

## How it works

The Pi agent role now manages both settings.json and mcp.json from role variables. It creates the Pi agent directory once, splits settings and MCP work into separate task files, and merges configured MCP servers into `~/.pi/agent/mcp.json`. The global AGENTS.md template adds mandatory routing guidance for context-mode commands, memory lookup, web fetches, and terse output.

## Links

None.
