### PR TITLE
Add MCP adapter package for Pi

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -175,6 +175,7 @@ pi_agent_settings_packages:
   - "git:github.com/boga/pi-local-claude-loader"
   - "npm:@plannotator/pi-extension"
   - "npm:context-mode"
+  - "npm:pi-mcp-adapter"
   - "npm:pi-mono-ask-user-question"
   - "npm:pi-subagents"
   - "npm:taskplane"


### PR DESCRIPTION
## Why

Pi should install the MCP adapter through the managed agent package list so it stays in sync with the rest of the Pi setup.

## Approach

Add the npm package reference to the shared Pi package configuration.

## How it works

The pi_agent role writes settings.json with the configured package list, then pi update --extensions installs and updates managed Pi packages.

## Links

- None