### PR TITLE
Update README setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,67 @@
 # Dotfiles
 
-## Bootstrap requirement
+Automate macOS workstation setup with Ansible. The playbook installs Homebrew packages, copies shell and editor configuration, configures global Git identity, writes Worktrunk shell integration, and installs Pi agent settings.
 
-`op` (the 1Password CLI) must already be installed and signed in before you bootstrap this machine. The playbook uses it to read the Ansible vault password during setup, so bootstrapping will fail if the CLI is unavailable.
+## Bootstrap requirements
 
-Because both inventory entries target `localhost`, you should limit each run to the laptop you are currently on. This ensures Ansible loads the correct host-specific variables:
+Install and sign in to the 1Password CLI before running the playbook. `ansible.cfg` uses `./vault-password.sh`, which reads the Ansible vault password from 1Password:
 
 ```bash
-ansible-playbook -i inventory.yml site.yml --limit home
-ansible-playbook -i inventory.yml site.yml --limit work
+op signin
+op read "op://Private/dotfiles Ansible vault/password"
 ```
 
-## Host variables and vault files
+Install Ansible before the first run if the machine does not have it yet:
 
-Host-specific variables are split into plain and vaulted files so Ansible auto-loads them for the matching host:
+```bash
+brew install ansible
+```
+
+## Hosts
+
+Both inventory entries target `localhost`:
+
+- `home` configures the home laptop.
+- `work` configures the work laptop.
+
+**Always pass `--limit`** so Ansible loads one host's variables and does not run against both entries.
+
+```bash
+ansible-playbook site.yml --limit home
+ansible-playbook site.yml --limit work
+```
+
+## Repository layout
+
+- `site.yml` installs packages and runs configuration roles.
+- `inventory.yml` defines the `home` and `work` localhost targets.
+- `ansible.cfg` sets `inventory`, `roles_path`, and `vault_password_file`.
+- `group_vars/all.yml` defines shared Homebrew packages, casks, config file mappings, Git variables, and Pi agent packages.
+- `host_vars/<host>/vars.yml` defines host-specific non-secret values such as `ansible_user`, `ansible_group`, Python interpreter, and Firefox profile path.
+- `host_vars/<host>/vault.yml` stores vaulted host secrets such as Git name and email.
+- `roles/config_files/` templates files from `templates/` into the home directory.
+- `roles/git/` configures global Git identity and excludes.
+- `roles/pi_agent/` merges Pi `settings.json` and `mcp.json` without replacing unrelated existing keys.
+- `templates/` contains managed dotfiles, editor settings, agent skills, and Codex rules.
+
+## What the playbook manages
+
+The main playbook performs these steps:
+
+1. Install Homebrew taps from `homebrew_taps`.
+2. Update Homebrew and upgrade installed formulae.
+3. Install formulae from `homebrew_packages`.
+4. Install casks from `homebrew_casks`.
+5. Copy templated config files listed in `config_files`.
+6. Configure global Git user name, email, and excludes file.
+7. Create `~/.config/mise/conf.d`.
+8. Generate Worktrunk shell integration at `~/.zshrc.worktrunk`.
+9. Configure Pi agent settings and MCP servers.
+10. Run `mise upgrade` and `pi update --extensions` after the main tasks.
+
+## Vault files
+
+Host-specific variables are split so Ansible can auto-load plain values and encrypted secrets for the selected host:
 
 ```text
 host_vars/
@@ -25,29 +73,38 @@ host_vars/
     vault.yml
 ```
 
-- `host_vars/<host>/vars.yml` stores non-secret host settings such as `ansible_user`, Python path, and Firefox profile path.
-- `host_vars/<host>/vault.yml` stores vaulted secrets such as `vault_git_user_name` and `vault_git_user_email`.
-- `group_vars/all.yml` maps shared variables like `git_user_name` and `git_user_email` from the vaulted values.
+Edit vaulted files with Ansible Vault so `vault-password.sh` can fetch the password from 1Password:
 
-The repository is configured to use `./vault-password.txt` for vault operations:
+```bash
+ansible-vault edit host_vars/home/vault.yml
+ansible-vault edit host_vars/work/vault.yml
+```
+
+Encrypt a new or decrypted vault file with:
 
 ```bash
 ansible-vault encrypt host_vars/home/vault.yml
 ansible-vault encrypt host_vars/work/vault.yml
 ```
 
-`vault-password.txt` must exist locally and must be a plain text password file, not an executable script:
+## Validation
+
+Check syntax before applying changes:
 
 ```bash
-chmod 600 ./vault-password.txt
-chmod -x ./vault-password.txt
+ansible-playbook site.yml --limit home --syntax-check
+ansible-playbook site.yml --limit work --syntax-check
 ```
 
-## Validating config changes
-
-Use check mode for the config-related tasks on the target host:
+Preview the task list for one host:
 
 ```bash
-ansible-playbook -i inventory.yml site.yml --limit home --tags configs --check
-ansible-playbook -i inventory.yml site.yml --limit work --tags configs --check
+ansible-playbook site.yml --limit home --list-tasks
+```
+
+Run check mode when you need a dry run:
+
+```bash
+ansible-playbook site.yml --limit home --check --diff
+ansible-playbook site.yml --limit work --check --diff
 ```


### PR DESCRIPTION
## Why

The README had outdated bootstrap and vault guidance and did not explain the current playbook flow, roles, or managed configuration clearly.

## Approach

Reviewed the Ansible playbook, shared variables, inventory, roles, and vault helper script, then rewrote the README around the current repository structure and operational workflow.

## How it works

Documents the 1Password-backed vault password flow, host limiting requirement, repository layout, playbook steps, vault file workflow, and validation commands for syntax checks, task listing, and dry runs.

## Links

- None
