### PR TITLE
Add Pi scout-n-plan chain and /plan prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 !templates/mise.toml
 # AGENTS.md is gitignored globally; un-ignore it for this repo
 !templates/pi/AGENTS.md
+# PLAN.md is gitignored globally; un-ignore prompt template
+!templates/pi/prompts/plan.md
 CLAUDE.local.md
 .pi
 *env*

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -166,6 +166,9 @@ config_files:
   - name: "Pi chain: scout-n-plan"
     src: "./templates/pi/chains/scout-n-plan.chain.md"
     dest: "~/.pi/agent/chains/scout-n-plan.chain.md"
+  - name: "Pi prompt: plan"
+    src: "./templates/pi/prompts/plan.md"
+    dest: "~/.pi/agent/prompts/plan.md"
 
 pi_agent_settings_path: "~/.pi/agent/settings.json"
 pi_agent_settings_overrides: |-

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -163,6 +163,9 @@ config_files:
   - name: "Pi markdown styleguide"
     src: "./templates/pi/STYLEGUIDE_MARKDOWN.md"
     dest: "~/.pi/agent/STYLEGUIDE_MARKDOWN.md"
+  - name: "Pi chain: scout-n-plan"
+    src: "./templates/pi/chains/scout-n-plan.chain.md"
+    dest: "~/.pi/agent/chains/scout-n-plan.chain.md"
 
 pi_agent_settings_path: "~/.pi/agent/settings.json"
 pi_agent_settings_overrides: |-

--- a/roles/pi_agent/README.md
+++ b/roles/pi_agent/README.md
@@ -1,6 +1,6 @@
 # pi_agent
 
-Installs and configures the [Pi coding agent](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) on macOS.
+Installs and configures the [Pi coding agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) on macOS.
 
 ## What it does
 

--- a/templates/mise.toml
+++ b/templates/mise.toml
@@ -4,5 +4,5 @@ _.path = "/Applications/IntelliJ IDEA.app/Contents/MacOS"
 [tools]
 node = "25"
 bun  = "latest"
-"npm:@mariozechner/pi-coding-agent" = "latest"
+"npm:@earendil-works/pi-coding-agent" = "latest"
 "npm:context-mode" = "latest"

--- a/templates/pi/chains/scout-n-plan.chain.md
+++ b/templates/pi/chains/scout-n-plan.chain.md
@@ -1,0 +1,17 @@
+<!-- {{ ansible_managed }} --->
+
+---
+name: scout-n-plan
+description: Gather context then plan implementation
+---
+
+## scout
+output: context.md
+
+Analyze the codebase for {task}
+
+## planner
+reads: context.md
+output: plan.md
+
+Create an implementation plan based on {previous}. Save the plan to plan.md. When done, report the full path to plan.md.

--- a/templates/pi/prompts/plan.md
+++ b/templates/pi/prompts/plan.md
@@ -1,0 +1,5 @@
+---
+description: Scout the codebase and create an implementation plan
+argument-hint: "<task>"
+---
+Run the scout-n-plan chain using the subagent tool with `chainName: "scout-n-plan"` and `task: "$@"`.


### PR DESCRIPTION
## Summary

- Add a `scout-n-plan` Pi chain template that scouts codebase context before planning implementation.
- Deploy the chain and `/plan` prompt through Ansible config files.
- Switch Pi package references to the `@earendil-works/pi-coding-agent` package.

## Testing

- Not run; configuration/template-only change.