### PR TITLE
Fix Pi chain frontmatter placement

### DIFF
--- a/templates/pi/chains/scout-n-plan.chain.md
+++ b/templates/pi/chains/scout-n-plan.chain.md
@@ -1,5 +1,3 @@
-<!-- {{ ansible_managed }} --->
-
 ---
 name: scout-n-plan
 description: Gather context then plan implementation
@@ -15,3 +13,5 @@ reads: context.md
 output: plan.md
 
 Create an implementation plan based on {previous}. Save the plan to plan.md. When done, report the full path to plan.md.
+
+<!-- {{ ansible_managed }} --->


### PR DESCRIPTION
## Why

Pi subagent chain discovery requires YAML frontmatter at the start of `.chain.md` files. The managed-file comment before frontmatter can prevent the chain from being discovered.

## Approach

Move the Ansible managed comment from the top of the chain template to the bottom, preserving the generated management marker without blocking frontmatter parsing.

## How it works

The `scout-n-plan` chain template now starts with YAML frontmatter and keeps the Ansible managed comment after the chain steps.

## Links

- None
