### PR TITLE
Remove Taskplane from Pi packages

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -187,4 +187,3 @@ pi_agent_settings_packages:
   - "npm:pi-mcp-adapter"
   - "npm:pi-mono-ask-user-question"
   - "npm:pi-subagents"
-  - "npm:taskplane"


### PR DESCRIPTION
## Why

Taskplane should no longer be installed as a managed Pi agent extension package.

## Approach

Remove only the Taskplane package entry from the shared Pi package list. Leave prompts, chains, docs, and host overrides unchanged.

## How it works

Ansible will stop rendering npm:taskplane into ~/.pi/agent/settings.json when the Pi settings package list is applied.

## Validation

- git grep -n -i taskplane -- ':!.git'
- ansible-playbook site.yml --limit home --syntax-check
- ansible-playbook site.yml --limit work --syntax-check