### PR TITLE
Fix Ansible managed header fact lookup

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-ansible_managed: "Ansible managed: {{ template_path }} by {{ ansible_user_id | default(ansible_user) }} on {{ inventory_hostname }}"
+ansible_managed: "Ansible managed: {{ template_path }} by {{ ansible_facts['user_id'] | default(ansible_user) }} on {{ inventory_hostname }}"
 
 git_user_email: "{{ vault_git_user_email }}"
 git_user_name: "{{ vault_git_user_name }}"


### PR DESCRIPTION
## Why

Ansible warns that top-level fact variable injection is deprecated for ansible_user_id.

## Approach

Use the explicit ansible_facts mapping while preserving the existing ansible_user fallback.

## How it works

Updates the ansible_managed template string in group_vars/all.yml to read ansible_facts['user_id'] instead of ansible_user_id.

## Links

- None