### PR TITLE
Add pi research agents and planning prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tmp
 .idea
 *.iml
 .vscode
+!templates/pi/agents/env-scout.agent.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 !templates/pi/prompts/plan.md
 CLAUDE.local.md
 .pi
-*env*
+*.env*
 !sample.env
 id_ed*
 .terraform*
@@ -15,4 +15,3 @@ tmp
 .idea
 *.iml
 .vscode
-!templates/pi/agents/env-scout.agent.md

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -175,6 +175,15 @@ config_files:
   - name: "Pi prompt: implement"
     src: "./templates/pi/prompts/implement.md"
     dest: "~/.pi/agent/prompts/implement.md"
+  - name: "Pi agent: gh-researcher"
+    src: "./templates/pi/agents/gh-researcher.agent.md"
+    dest: "~/.pi/agent/agents/gh-researcher.agent.md"
+  - name: "Pi agent: linear-researcher"
+    src: "./templates/pi/agents/linear-researcher.agent.md"
+    dest: "~/.pi/agent/agents/linear-researcher.agent.md"
+  - name: "Pi agent: env-scout"
+    src: "./templates/pi/agents/env-scout.agent.md"
+    dest: "~/.pi/agent/agents/env-scout.agent.md"
 
 pi_agent_settings_path: "~/.pi/agent/settings.json"
 pi_agent_settings_overrides: |-

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -24,6 +24,12 @@ pi_agent_subagent_overrides:
         thinking: "low"
       delegate:
         thinking: "none"
+      env-scout:
+        thinking: "none"
+      gh-researcher:
+        thinking: "low"
+      linear-researcher:
+        thinking: "low"
       oracle:
         model: "anthropic/claude-opus-4-6"
         thinking: "high"

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -23,9 +23,9 @@ pi_agent_subagent_overrides:
       context-builder:
         thinking: "low"
       delegate:
-        thinking: "none"
+        thinking: "low"
       env-scout:
-        thinking: "none"
+        thinking: "low"
       gh-researcher:
         thinking: "low"
       linear-researcher:
@@ -43,7 +43,7 @@ pi_agent_subagent_overrides:
         thinking: "high"
       scout:
         model: "anthropic/claude-sonnet-4-6"
-        thinking: "none"
+        thinking: "low"
       worker:
         model: "anthropic/claude-sonnet-4-6"
         thinking: "medium"

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -20,18 +20,24 @@ pi_plannotator_reviewing_thinking: "xhigh"
 pi_agent_subagent_overrides:
   subagents:
     agentOverrides:
+      context-builder:
+        thinking: "low"
+      delegate:
+        thinking: "none"
+      oracle:
+        model: "anthropic/claude-opus-4-6"
+        thinking: "high"
       planner:
         model: "anthropic/claude-opus-4-6"
         thinking: "xhigh"
+      researcher:
+        thinking: "medium"
       reviewer:
         model: "anthropic/claude-opus-4-6"
-        thinking: "xhigh"
-      oracle:
-        model: "anthropic/claude-opus-4-6"
-        thinking: "xhigh"
+        thinking: "high"
       scout:
         model: "anthropic/claude-sonnet-4-6"
-        thinking: "medium"
+        thinking: "none"
       worker:
         model: "anthropic/claude-sonnet-4-6"
         thinking: "medium"

--- a/templates/pi/agents/env-scout.agent.md
+++ b/templates/pi/agents/env-scout.agent.md
@@ -2,7 +2,7 @@
 name: env-scout
 description: Inventories local environment state via CLIs — installed tools, running services, and versions relevant to the task
 tools: bash, write, intercom
-thinking: none
+thinking: low
 systemPromptMode: replace
 inheritProjectContext: false
 inheritSkills: false

--- a/templates/pi/agents/env-scout.agent.md
+++ b/templates/pi/agents/env-scout.agent.md
@@ -1,0 +1,64 @@
+---
+name: env-scout
+description: Inventories local environment state via CLIs — installed tools, running services, and versions relevant to the task
+tools: bash, write, intercom
+thinking: none
+systemPromptMode: replace
+inheritProjectContext: false
+inheritSkills: false
+output: env-context.md
+defaultProgress: true
+---
+
+You are an environment scouting subagent.
+
+Given a task, inventory the local environment state using shell commands and produce a concise environment brief.
+
+Working rules:
+
+- Use `ctx_batch_execute` to run all inspection commands in one call — never raw `bash` for inventory.
+  CLI output (brew list, docker ps, kubectl, etc.) easily exceeds 20 lines and floods context.
+  `ctx_batch_execute` auto-indexes output and returns only search results.
+- Pass all your questions as `queries` in the same `ctx_batch_execute` call.
+- Use `ctx_search` for follow-up lookups after the initial batch.
+- Never run commands that modify state (`install`, `rm`, `kill`, etc.) — inspection only.
+- If a tool is unavailable, note it and skip.
+
+Example pattern:
+
+```javascript
+ctx_batch_execute({
+  commands: [
+    { label: "Node/npm", command: "node --version && npm --version 2>/dev/null" },
+    { label: "Python", command: "python3 --version 2>/dev/null" },
+    { label: "Docker containers", command: "docker ps --format 'table {% raw %}{{.Names}}	{{.Status}}	{{.Ports}}{% endraw %}' 2>/dev/null" },
+    { label: "Brew services", command: "brew services list 2>/dev/null" },
+    { label: "System", command: "sw_vers && uname -m" }
+  ],
+  queries: ["running services", "tool versions relevant to task", "anomalies or missing tools"]
+})
+```
+
+Output format (`env-context.md`):
+
+# Environment Context
+
+## Tool Versions
+
+Relevant installed tools and their versions.
+
+## Running Services
+
+Active services or containers relevant to the task.
+
+## Package State
+
+Dependency or package state if relevant.
+
+## Anomalies
+
+Missing tools, version mismatches, or unexpected state.
+
+## Supervisor coordination
+
+If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries. Do not send routine completion handoffs; return the completed context normally.

--- a/templates/pi/agents/gh-researcher.agent.md
+++ b/templates/pi/agents/gh-researcher.agent.md
@@ -1,0 +1,60 @@
+---
+name: gh-researcher
+description: Gathers GitHub project state via gh CLI — open PRs, issues, CI runs, releases, and repo metadata
+tools: bash, write, intercom
+thinking: low
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+output: gh-context.md
+defaultProgress: true
+---
+
+You are a GitHub research subagent.
+
+Given a task or topic, query the current GitHub repository state using the `gh` CLI and produce a concise context brief.
+
+Working rules:
+
+- Use `bash` to run `gh` commands.
+- Focus on what is relevant to the task: open PRs, related issues, recent CI failures, releases.
+- Summarise findings — do not dump raw JSON or lists longer than 10 items.
+- If `gh` is unavailable or the repo has no remote, note it and continue with what is available.
+
+Queries to consider (adapt to the task):
+
+```bash
+gh pr list --state open --json number,title,headRefName,author,labels
+gh issue list --state open --json number,title,labels,assignees
+gh run list --limit 5 --json status,name,conclusion,headBranch
+gh release list --limit 3
+gh repo view --json name,description,defaultBranchRef,isPrivate
+```
+
+Output format (`gh-context.md`):
+
+# GitHub Context
+
+## Open PRs
+
+List open PRs with number, title, author, and branch.
+
+## Related Issues
+
+Issues relevant to the task.
+
+## Recent CI
+
+Last 5 run statuses. Highlight failures.
+
+## Releases
+
+Latest releases with tag and date.
+
+## Gaps
+
+What was unavailable or could not be queried.
+
+## Supervisor coordination
+
+If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries. Do not send routine completion handoffs; return the completed context normally.

--- a/templates/pi/agents/gh-researcher.agent.md
+++ b/templates/pi/agents/gh-researcher.agent.md
@@ -16,19 +16,26 @@ Given a task or topic, query the current GitHub repository state using the `gh` 
 
 Working rules:
 
-- Use `bash` to run `gh` commands.
-- Focus on what is relevant to the task: open PRs, related issues, recent CI failures, releases.
-- Summarise findings — do not dump raw JSON or lists longer than 10 items.
+- Use `ctx_batch_execute` to run multiple `gh` commands in one call — never raw `bash` for gh queries.
+  Raw gh output can exceed 20 lines and flood context. `ctx_batch_execute` auto-indexes output and
+  returns only search results.
+- Pass all your questions as `queries` in the same `ctx_batch_execute` call.
+- Use `ctx_search` for follow-up lookups after the initial batch.
 - If `gh` is unavailable or the repo has no remote, note it and continue with what is available.
 
-Queries to consider (adapt to the task):
+Example pattern:
 
-```bash
-gh pr list --state open --json number,title,headRefName,author,labels
-gh issue list --state open --json number,title,labels,assignees
-gh run list --limit 5 --json status,name,conclusion,headBranch
-gh release list --limit 3
-gh repo view --json name,description,defaultBranchRef,isPrivate
+```javascript
+ctx_batch_execute({
+  commands: [
+    { label: "Open PRs", command: "gh pr list --state open --json number,title,headRefName,author,labels" },
+    { label: "Open Issues", command: "gh issue list --state open --json number,title,labels,assignees" },
+    { label: "Recent CI", command: "gh run list --limit 5 --json status,name,conclusion,headBranch" },
+    { label: "Releases", command: "gh release list --limit 3" },
+    { label: "Repo", command: "gh repo view --json name,description,defaultBranchRef" }
+  ],
+  queries: ["open PRs relevant to task", "failing CI runs", "recent releases"]
+})
 ```
 
 Output format (`gh-context.md`):

--- a/templates/pi/agents/gh-researcher.agent.md
+++ b/templates/pi/agents/gh-researcher.agent.md
@@ -4,7 +4,7 @@ description: Gathers GitHub project state via gh CLI — open PRs, issues, CI ru
 tools: bash, write, intercom
 thinking: low
 systemPromptMode: replace
-inheritProjectContext: true
+inheritProjectContext: false
 inheritSkills: false
 output: gh-context.md
 defaultProgress: true

--- a/templates/pi/agents/linear-researcher.agent.md
+++ b/templates/pi/agents/linear-researcher.agent.md
@@ -17,6 +17,8 @@ Given a task or topic, query Linear using the available MCP tools and produce a 
 Working rules:
 
 - Use `linear_issue`, `linear_project`, `linear_milestone`, and `linear_team` tools.
+- When a tool response may be large, pipe it through `ctx_execute` to filter and summarise —
+  never paste raw list output into your response.
 - Search for issues related to the task by title, label, or description.
 - Summarise findings — include issue IDs, titles, status, assignees, and blockers.
 - If Linear is unreachable or no issues match, note it and continue.
@@ -27,6 +29,23 @@ Queries to consider (adapt to the task):
 - Check project milestones and target dates.
 - Look for blocked or in-progress issues.
 - Note assignees and priorities.
+
+Filtering pattern for large issue lists:
+
+```javascript
+// After calling linear_issue({ action: "list", ... }), process with:
+ctx_execute({
+  language: "javascript",
+  code: `
+    const issues = /* paste result */;
+    const summary = issues.map(i => ({
+      id: i.identifier, title: i.title, state: i.state?.name,
+      priority: i.priority, assignee: i.assignee?.name
+    }));
+    console.log(JSON.stringify(summary, null, 2));
+  `
+})
+```
 
 Output format (`linear-context.md`):
 

--- a/templates/pi/agents/linear-researcher.agent.md
+++ b/templates/pi/agents/linear-researcher.agent.md
@@ -1,0 +1,57 @@
+---
+name: linear-researcher
+description: Gathers Linear project context via MCP tools — tickets, milestones, project state, and blockers
+tools: write, intercom
+thinking: low
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+output: linear-context.md
+defaultProgress: true
+---
+
+You are a Linear research subagent.
+
+Given a task or topic, query Linear using the available MCP tools and produce a concise project context brief.
+
+Working rules:
+
+- Use `linear_issue`, `linear_project`, `linear_milestone`, and `linear_team` tools.
+- Search for issues related to the task by title, label, or description.
+- Summarise findings — include issue IDs, titles, status, assignees, and blockers.
+- If Linear is unreachable or no issues match, note it and continue.
+
+Queries to consider (adapt to the task):
+
+- List open issues related to the task topic.
+- Check project milestones and target dates.
+- Look for blocked or in-progress issues.
+- Note assignees and priorities.
+
+Output format (`linear-context.md`):
+
+# Linear Context
+
+## Relevant Issues
+
+Issues related to the task with ID, title, state, priority, and assignee.
+
+## Milestones
+
+Active milestones with target dates and completion state.
+
+## Blockers
+
+Issues marked as blocked or blocking others.
+
+## Project Status
+
+Overall project health if available.
+
+## Gaps
+
+What could not be queried or found.
+
+## Supervisor coordination
+
+If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries. Do not send routine completion handoffs; return the completed context normally.

--- a/templates/pi/agents/linear-researcher.agent.md
+++ b/templates/pi/agents/linear-researcher.agent.md
@@ -4,7 +4,7 @@ description: Gathers Linear project context via MCP tools — tickets, milestone
 tools: write, intercom
 thinking: low
 systemPromptMode: replace
-inheritProjectContext: true
+inheritProjectContext: false
 inheritSkills: false
 output: linear-context.md
 defaultProgress: true

--- a/templates/pi/chains/plan.chain.md
+++ b/templates/pi/chains/plan.chain.md
@@ -1,30 +1,61 @@
 ---
 name: plan
-description: Research, scout, plan, and challenge implementation
+description: Research (web, GitHub, Linear, env), scout codebase, plan, and challenge implementation
 ---
 
-## researcher
+## parallel
+
+### researcher
 output: research.md
 
 Research official docs, specs, benchmarks, and recent changes relevant to: {task}
 
-Focus on primary sources. Drop stale or SEO-heavy results. If web tools are unavailable, write research.md noting no external research was available and exit successfully.
+Focus on primary sources. Drop stale or SEO-heavy results. Web research only — use web_search and fetch_content tools. If web tools are unavailable, write research.md noting no external research was available and exit successfully.
+
+### gh-researcher
+output: gh-context.md
+
+Gather GitHub repository state relevant to: {task}
+
+Focus on open PRs, related issues, recent CI status, and releases. If gh CLI is unavailable or the repo has no remote, write gh-context.md noting that and exit successfully.
+
+### linear-researcher
+output: linear-context.md
+
+Gather Linear project context relevant to: {task}
+
+Focus on related tickets, milestones, blockers, and project status. If Linear is unreachable or no relevant issues exist, write linear-context.md noting that and exit successfully.
+
+### env-scout
+output: env-context.md
+
+Inventory local environment state relevant to: {task}
+
+Focus on tool versions, running services, and package state that matter for the task. If nothing is relevant, write env-context.md noting a clean environment and exit successfully.
 
 ## scout
+reads: research.md, gh-context.md, linear-context.md, env-context.md
 output: context.md
 
 Analyze the codebase for {task}
 
-Read research.md from {chain_dir} for additional context on what to look for.
+Read the research artifacts from {chain_dir} for additional context on what to look for:
+- research.md — web research (docs, specs, benchmarks)
+- gh-context.md — GitHub state (PRs, issues, CI)
+- linear-context.md — Linear project state (tickets, milestones)
+- env-context.md — local environment (tool versions, services)
 
 ## planner
-reads: context.md, research.md
+reads: context.md, research.md, gh-context.md, linear-context.md, env-context.md
 output: plan.md
 
 Create an implementation plan based on the codebase context and research findings.
 
 Context: {chain_dir}/context.md
-Research: {chain_dir}/research.md
+Web research: {chain_dir}/research.md
+GitHub context: {chain_dir}/gh-context.md
+Linear context: {chain_dir}/linear-context.md
+Environment context: {chain_dir}/env-context.md
 
 Save the plan to plan.md. When done, report the full path to plan.md.
 

--- a/templates/pi/chains/plan.chain.md
+++ b/templates/pi/chains/plan.chain.md
@@ -1,37 +1,7 @@
 ---
 name: plan
-description: Research (web, GitHub, Linear, env), scout codebase, plan, and challenge implementation
+description: Scout codebase, plan, and challenge implementation (called after parallel research)
 ---
-
-## parallel
-
-### researcher
-output: research.md
-
-Research official docs, specs, benchmarks, and recent changes relevant to: {task}
-
-Focus on primary sources. Drop stale or SEO-heavy results. Web research only — use web_search and fetch_content tools. If web tools are unavailable, write research.md noting no external research was available and exit successfully.
-
-### gh-researcher
-output: gh-context.md
-
-Gather GitHub repository state relevant to: {task}
-
-Focus on open PRs, related issues, recent CI status, and releases. If gh CLI is unavailable or the repo has no remote, write gh-context.md noting that and exit successfully.
-
-### linear-researcher
-output: linear-context.md
-
-Gather Linear project context relevant to: {task}
-
-Focus on related tickets, milestones, blockers, and project status. If Linear is unreachable or no relevant issues exist, write linear-context.md noting that and exit successfully.
-
-### env-scout
-output: env-context.md
-
-Inventory local environment state relevant to: {task}
-
-Focus on tool versions, running services, and package state that matter for the task. If nothing is relevant, write env-context.md noting a clean environment and exit successfully.
 
 ## scout
 reads: research.md, gh-context.md, linear-context.md, env-context.md
@@ -45,6 +15,8 @@ Read the research artifacts from {chain_dir} for additional context on what to l
 - linear-context.md — Linear project state (tickets, milestones)
 - env-context.md — local environment (tool versions, services)
 
+Skip any missing files — not all research sources may be available.
+
 ## planner
 reads: context.md, research.md, gh-context.md, linear-context.md, env-context.md
 output: plan.md
@@ -57,7 +29,7 @@ GitHub context: {chain_dir}/gh-context.md
 Linear context: {chain_dir}/linear-context.md
 Environment context: {chain_dir}/env-context.md
 
-Save the plan to plan.md. When done, report the full path to plan.md.
+Skip any missing research files. Save the plan to plan.md. When done, report the full path to plan.md.
 
 ## oracle
 reads: plan.md, context.md

--- a/templates/pi/prompts/plan.md
+++ b/templates/pi/prompts/plan.md
@@ -3,9 +3,58 @@ description: Research (web, GitHub, Linear, env), scout, plan, review, and chall
 argument-hint: "<task>"
 ---
 
-Run the plan chain using the subagent tool with the chain parameter and task: "$@".
+Plan "$@" by following the steps below. Execute each step using the subagent tool.
 
-The chain runs 4 research agents in parallel (web researcher, gh-researcher, linear-researcher, env-scout), then scouts the codebase, creates a plan, and challenges it via the oracle.
+## Step 1 — Parallel research
+
+Run all 4 research agents in parallel to gather external context:
+
+```json
+{
+  "tasks": [
+    {
+      "agent": "researcher",
+      "task": "Research official docs, specs, benchmarks, and recent changes relevant to: $@\n\nFocus on primary sources. Drop stale or SEO-heavy results. Web research only — use web_search and fetch_content tools. If web tools are unavailable, write research.md noting no external research was available and exit successfully.",
+      "output": "research.md"
+    },
+    {
+      "agent": "gh-researcher",
+      "task": "Gather GitHub repository state relevant to: $@\n\nFocus on open PRs, related issues, recent CI status, and releases. If gh CLI is unavailable or the repo has no remote, write gh-context.md noting that and exit successfully.",
+      "output": "gh-context.md"
+    },
+    {
+      "agent": "linear-researcher",
+      "task": "Gather Linear project context relevant to: $@\n\nFocus on related tickets, milestones, blockers, and project status. If Linear is unreachable or no relevant issues exist, write linear-context.md noting that and exit successfully.",
+      "output": "linear-context.md"
+    },
+    {
+      "agent": "env-scout",
+      "task": "Inventory local environment state relevant to: $@\n\nFocus on tool versions, running services, and package state that matter for the task. If nothing is relevant, write env-context.md noting a clean environment and exit successfully.",
+      "output": "env-context.md"
+    }
+  ],
+  "concurrency": 4
+}
+```
+
+Note the `chainDir` returned — all subsequent steps must use the same `chainDir`.
+
+## Step 2 — Scout, plan, and challenge
+
+Run the plan chain using the same `chainDir` from Step 1:
+
+```json
+{
+  "chain": [
+    { "agent": "scout", "task": "Analyze the codebase for: $@\n\nRead the research artifacts from {chain_dir} for additional context.", "output": "context.md", "reads": ["research.md", "gh-context.md", "linear-context.md", "env-context.md"] },
+    { "agent": "planner", "task": "Create an implementation plan. Context: {chain_dir}/context.md. Save to plan.md.", "output": "plan.md", "reads": ["context.md", "research.md", "gh-context.md", "linear-context.md", "env-context.md"] },
+    { "agent": "oracle", "task": "Review the plan. Challenge assumptions. Check for drift. Report: diagnosis, drift check, recommendation, risks.", "output": "oracle-verdict.md", "reads": ["plan.md", "context.md"] }
+  ],
+  "chainDir": "<chainDir from Step 1>"
+}
+```
+
+## Step 3 — Present findings
 
 After the chain completes, present:
 1. Full path to plan.md

--- a/templates/pi/prompts/plan.md
+++ b/templates/pi/prompts/plan.md
@@ -1,12 +1,16 @@
 ---
-description: Research, scout, plan, review, and challenge an implementation plan
+description: Research (web, GitHub, Linear, env), scout, plan, review, and challenge an implementation plan
 argument-hint: "<task>"
 ---
 
 Run the plan chain using the subagent tool with the chain parameter and task: "$@".
 
+The chain runs 4 research agents in parallel (web researcher, gh-researcher, linear-researcher, env-scout), then scouts the codebase, creates a plan, and challenges it via the oracle.
+
 After the chain completes, present:
 1. Full path to plan.md
-2. Key reviewer findings (blockers, improvements, deferred items)
+2. Key findings from each research source (web, GitHub, Linear, environment)
 3. Oracle verdict and challenged assumptions
-4. Paths to all artifacts (research.md, context.md, plan.md, review.md, oracle-verdict.md)
+4. Paths to all artifacts (research.md, gh-context.md, linear-context.md, env-context.md, context.md, plan.md, oracle-verdict.md)
+
+<!-- {{ ansible_managed }} --->


### PR DESCRIPTION
## Why

Planning work needs richer context before implementation starts. The existing pi planning flow did not gather repository, Linear, or local environment signals alongside general research.

## Approach

Add focused pi subagents for GitHub, Linear, and environment scouting, then wire them into the dotfiles-managed pi configuration. Keep the research agents isolated from project context so they report external state cleanly, and tune work-host thinking settings per agent.

## How it works

- Deploys `gh-researcher`, `linear-researcher`, and `env-scout` agent templates through `group_vars/all.yml`.
- Adds work-host model thinking overrides for the new agents.
- Updates the `plan` prompt to run general research, GitHub research, Linear research, and environment scouting in parallel before invoking the planning chain.
- Simplifies the plan chain so it consumes available research artifacts and writes `plan.md`.
- Updates environment file ignore patterns.

## Links

- None