### PR TITLE
Fix home Pi subagent models

### DIFF
--- a/host_vars/home/vars.yml
+++ b/host_vars/home/vars.yml
@@ -7,13 +7,31 @@ firefox_profile_dir: /Users/miju/Library/Application Support/Firefox/Profiles/pe
 pi_agent_subagent_overrides:
   subagents:
     agentOverrides:
+      context-builder:
+        model: "openai-codex/gpt-5.5"
+        thinking: "low"
+      delegate:
+        model: "openai-codex/gpt-5.5"
+        thinking: "low"
+      env-scout:
+        model: "openai-codex/gpt-5.5"
+        thinking: "low"
+      gh-researcher:
+        model: "openai-codex/gpt-5.5"
+        thinking: "low"
+      linear-researcher:
+        model: "openai-codex/gpt-5.5"
+        thinking: "low"
+      oracle:
+        model: "openai-codex/gpt-5.5"
+        thinking: "xhigh"
       planner:
         model: "openai-codex/gpt-5.5"
         thinking: "xhigh"
-      reviewer:
+      researcher:
         model: "openai-codex/gpt-5.5"
-        thinking: "xhigh"
-      oracle:
+        thinking: "medium"
+      reviewer:
         model: "openai-codex/gpt-5.5"
         thinking: "xhigh"
       scout:


### PR DESCRIPTION
## Why

The home laptop Pi config did not set model overrides for the subagents added in PR #68. Those agents could inherit an unintended default model instead of the configured home Pi LLM.

## Approach

Mirror the work-host override coverage while keeping the home laptop on the existing `openai-codex/gpt-5.5` model family and preserving current thinking levels.

## How it works

- Adds home overrides for `context-builder`, `delegate`, `env-scout`, `gh-researcher`, `linear-researcher`, and `researcher`.
- Keeps planning, review, scout, and worker overrides on the same home model.
- Validates the host-specific Ansible playbook syntax for `home`.

## Links

- Follow-up to #68
