### PR TITLE
Add Context7 MCP server to Pi

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -194,6 +194,9 @@ pi_agent_settings_overrides: |-
 pi_agent_mcp_servers:
   context-mode:
     command: "context-mode"
+  context7:
+    type: "streamable-http"
+    url: "https://mcp.context7.com/mcp"
 
 pi_agent_settings_packages:
   - "git:github.com/boga/pi-local-claude-loader"


### PR DESCRIPTION
## Why

 Context7 MCP server provides up-to-date, version-specific library documentation directly
 in the coding context. Agents can resolve library docs and code examples on demand without
 relying on stale training data.

 ## Approach

 Uses the remote streamable-HTTP transport (`https://mcp.context7.com/mcp`) — no local
 process to manage, works without an API key for basic usage, and stays consistent with
 the existing Pi `pi_agent_mcp_servers` pattern in `group_vars/all.yml`.

 ## How it works

 Adds a `context7` entry under `pi_agent_mcp_servers`. The existing `pi_agent` role's
 `tasks/mcp.yml` merges this into `~/.pi/agent/mcp.json` on the next Ansible run.

 ## Links

 - https://context7.com/docs/resources/all-clients