### PR TITLE
Add absolute path to COMMIT_MESSAGE_CONVENTION.md reference in AGENTS.md

### DIFF
--- a/templates/pi/AGENTS.md
+++ b/templates/pi/AGENTS.md
@@ -25,7 +25,7 @@ The only exception is when the user explicitly says something like *"commit dire
 
 ## Commit Message Convention
 
-Before composing commit messages, read and follow `COMMIT_MESSAGE_CONVENTION.md`.
+Before composing commit messages, read and follow `COMMIT_MESSAGE_CONVENTION.md` (`~/.pi/agent/COMMIT_MESSAGE_CONVENTION.md`).
 
 ## Commit and Push
 


### PR DESCRIPTION
   ## Why

   Agents running from arbitrary working directories couldn't reliably find
   `COMMIT_MESSAGE_CONVENTION.md` via the bare filename — the relative lookup
   would fail whenever the working directory wasn't `~/.pi/agent`.

   ## Approach

   Append the absolute path (`~/.pi/agent/COMMIT_MESSAGE_CONVENTION.md`) inline
   next to the existing filename reference. Minimal change — no restructuring
   needed, the hint is always visible in the same sentence.

   ## How it works

   The instruction in `templates/pi/AGENTS.md` now reads:

   > Before composing commit messages, read and follow `COMMIT_MESSAGE_CONVENTION.md`
   > (`~/.pi/agent/COMMIT_MESSAGE_CONVENTION.md`).

   Agents can fall back to the absolute path when the relative lookup fails.