### PR TITLE
Speed up plan and implement chains

### DIFF
--- a/templates/pi/chains/implement.chain.md
+++ b/templates/pi/chains/implement.chain.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: Build context, implement task, and run sequential reviewers
+description: Build context, implement, and run parallel reviewers
 ---
 
 ## context-builder
@@ -18,6 +18,29 @@ progress: true
 
 Implement {task} using the context and meta-prompt.
 
+If research artifacts exist in {chain_dir} (research.md, gh-context.md, linear-context.md, env-context.md), reference them for implementation details.
+
 Follow meta-prompt constraints exactly. Escalate unapproved decisions via `contact_supervisor` — do not guess or assume. No placeholders, no TODOs, no silent scope changes.
+
+## parallel
+concurrency: 3
+
+### reviewer
+reads: progress.md, context.md, meta-prompt.md, plan.md
+output: review-correctness.md
+
+Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.
+
+### reviewer
+reads: progress.md, context.md, meta-prompt.md, plan.md
+output: review-tests.md
+
+Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.
+
+### reviewer
+reads: progress.md, context.md, meta-prompt.md, plan.md
+output: review-cleanup.md
+
+Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.
 
 <!-- {{ ansible_managed }} --->

--- a/templates/pi/chains/plan.chain.md
+++ b/templates/pi/chains/plan.chain.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Scout codebase, plan, and challenge implementation (called after parallel research)
+description: Scout codebase, plan, and challenge implementation (expects research artifacts in chain_dir)
 ---
 
 ## scout
@@ -34,10 +34,10 @@ If you need to verify details or the context is insufficient, the raw research f
 Save the plan to plan.md. When done, report the full path to plan.md.
 
 ## oracle
-reads: plan.md, context.md
+reads: plan.md, context.md, research.md
 output: oracle-verdict.md
 
-Review the plan. Challenge assumptions. Check for drift from the original task requirements. Surface contradictions, hidden risks, and anything the planner may have missed.
+Review the plan. Challenge assumptions. Check for drift from the original task requirements. Cross-check claims against research sources. Surface contradictions, hidden risks, and anything the planner may have missed.
 
 Report: inherited decisions, diagnosis, drift check, recommendation, risks.
 

--- a/templates/pi/chains/plan.chain.md
+++ b/templates/pi/chains/plan.chain.md
@@ -18,18 +18,20 @@ Read the research artifacts from {chain_dir} for additional context on what to l
 Skip any missing files — not all research sources may be available.
 
 ## planner
-reads: context.md, research.md, gh-context.md, linear-context.md, env-context.md
+reads: context.md
 output: plan.md
 
-Create an implementation plan based on the codebase context and research findings.
+Create an implementation plan based on the codebase context.
 
-Context: {chain_dir}/context.md
-Web research: {chain_dir}/research.md
-GitHub context: {chain_dir}/gh-context.md
-Linear context: {chain_dir}/linear-context.md
-Environment context: {chain_dir}/env-context.md
+Primary input: {chain_dir}/context.md (scout's distilled codebase context including research findings).
 
-Skip any missing research files. Save the plan to plan.md. When done, report the full path to plan.md.
+If you need to verify details or the context is insufficient, the raw research files are available in {chain_dir}:
+- research.md — web research (docs, specs, benchmarks)
+- gh-context.md — GitHub state (PRs, issues, CI)
+- linear-context.md — Linear project state (tickets, milestones)
+- env-context.md — local environment (tool versions, services)
+
+Save the plan to plan.md. When done, report the full path to plan.md.
 
 ## oracle
 reads: plan.md, context.md

--- a/templates/pi/prompts/implement.md
+++ b/templates/pi/prompts/implement.md
@@ -27,25 +27,26 @@ Check the user's request:
 Check session state for a prior plan chain run:
 
 - **Prior plan chain ran in this session** — reuse its `chainDir`:
-  1. Skip context-builder.
-  2. Worker reads existing `plan.md` and `context.md` from that `chainDir`.
-  3. Go to Step 3.
+  1. Skip the implement chain. Run worker directly with `plan.md` and `context.md` from that `chainDir`.
+  2. Research artifacts (`research.md`, `gh-context.md`, `linear-context.md`, `env-context.md`) are available in the same `chainDir` — pass them to worker for additional context.
+  3. After worker completes, run parallel reviewers (Step 4) using the same `chainDir`.
+  4. Go to Step 5.
 
-- **No prior context**:
-  1. Run context-builder (Step 2A), then continue to Step 3.
-
-### Step 2A — Context building
+- **No prior context** — run the implement chain:
 
 ```json
 {
-  "agent": "context-builder",
-  "task": "Analyze the codebase for: $@"
+  "chain": "implement",
+  "task": "$@"
 }
 ```
 
-Outputs: `context.md`, `meta-prompt.md` in `{chain_dir}`.
+The chain runs: context-builder → worker → 3 parallel reviewers.
+Go to Step 5.
 
-## Step 3 — Implementation
+## Step 3 — Implementation (background/plan-reuse mode only)
+
+Only used when skipping the chain (background mode or prior plan reuse).
 
 ```json
 {
@@ -55,28 +56,29 @@ Outputs: `context.md`, `meta-prompt.md` in `{chain_dir}`.
 ```
 
 Worker reads: `context.md`, `meta-prompt.md` (or `plan.md` if from a prior plan chain).
+If research artifacts exist in `chainDir` (`research.md`, `gh-context.md`, `linear-context.md`, `env-context.md`), worker may reference them for implementation details.
 Output: `progress.md`.
 
-## Step 4 — Parallel review
+## Step 4 — Parallel review (background/plan-reuse/review-only mode)
 
-Run three reviewers in parallel. Each must **not** edit files — report findings only.
+Only used when not running the full implement chain (chain includes reviewers).
 
 ```json
 {
   "tasks": [
     {
       "agent": "reviewer",
-      "task": "Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints. Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
       "output": "review-correctness.md"
     },
     {
       "agent": "reviewer",
-      "task": "Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints. Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
       "output": "review-tests.md"
     },
     {
       "agent": "reviewer",
-      "task": "Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints. Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
       "output": "review-cleanup.md"
     }
   ],
@@ -84,7 +86,7 @@ Run three reviewers in parallel. Each must **not** edit files — report finding
 }
 ```
 
-Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md`.
+Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md`, `plan.md` (if available from prior plan chain).
 
 ## Step 5 — Present findings
 

--- a/templates/pi/prompts/implement.md
+++ b/templates/pi/prompts/implement.md
@@ -88,25 +88,30 @@ Only used when not running the full implement chain (chain includes reviewers).
 
 Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md`, `plan.md` (if available from prior plan chain).
 
-## Step 5 — Present findings
+## Step 5 — Apply fixes and present findings
 
-After reviewers complete, present to the user:
+After reviewers complete:
 
-1. Summary of what worker implemented (from `progress.md`).
-2. Key findings per reviewer — blockers first, then fixes, then notes.
-3. Paths to all artifacts: `context.md`, `meta-prompt.md`, `progress.md`, `review-correctness.md`, `review-tests.md`, `review-cleanup.md`.
+1. **If blockers found** — stop and present to the user:
+   - Summary of what worker implemented (from `progress.md`).
+   - Blockers that need user decision.
+   - Paths to all artifacts.
+   - **Wait for user confirmation before applying any fixes.**
 
-**Stop and wait for user confirmation before proceeding to Step 6.**
-
-## Step 6 — Apply fixes (only after user confirms)
+2. **If no blockers** — auto-apply non-blocker fixes:
 
 ```json
 {
   "agent": "worker",
-  "task": "Apply the reviewer fixes that make sense. Skip suggestions that conflict with meta-prompt constraints or expand scope. Report what was applied vs skipped with rationale."
+  "task": "Apply the reviewer fixes. Skip suggestions that conflict with meta-prompt constraints or expand scope. Report what was applied vs skipped with rationale."
 }
 ```
 
 Worker reads: `review-correctness.md`, `review-tests.md`, `review-cleanup.md`, `context.md`.
+
+Then present:
+   - Summary of what worker implemented and what fixes were applied.
+   - Key findings per reviewer — notes and suggestions that were skipped.
+   - Paths to all artifacts: `context.md`, `meta-prompt.md`, `progress.md`, `review-correctness.md`, `review-tests.md`, `review-cleanup.md`.
 
 <!-- {{ ansible_managed }} --->

--- a/templates/pi/prompts/plan.md
+++ b/templates/pi/prompts/plan.md
@@ -47,7 +47,7 @@ Run the plan chain using the same `chainDir` from Step 1:
 {
   "chain": [
     { "agent": "scout", "task": "Analyze the codebase for: $@\n\nRead the research artifacts from {chain_dir} for additional context.", "output": "context.md", "reads": ["research.md", "gh-context.md", "linear-context.md", "env-context.md"] },
-    { "agent": "planner", "task": "Create an implementation plan. Context: {chain_dir}/context.md. Save to plan.md.", "output": "plan.md", "reads": ["context.md", "research.md", "gh-context.md", "linear-context.md", "env-context.md"] },
+    { "agent": "planner", "task": "Create an implementation plan. Primary input: {chain_dir}/context.md. Raw research files are available in {chain_dir} if you need to verify details.", "output": "plan.md", "reads": ["context.md"] },
     { "agent": "oracle", "task": "Review the plan. Challenge assumptions. Check for drift. Report: diagnosis, drift check, recommendation, risks.", "output": "oracle-verdict.md", "reads": ["plan.md", "context.md"] }
   ],
   "chainDir": "<chainDir from Step 1>"

--- a/templates/pi/prompts/plan.md
+++ b/templates/pi/prompts/plan.md
@@ -5,9 +5,17 @@ argument-hint: "<task>"
 
 Plan "$@" by following the steps below. Execute each step using the subagent tool.
 
-## Step 1 — Parallel research
+## Step 1 — Conditional research
 
-Run all 4 research agents in parallel to gather external context:
+Check if these research artifacts already exist in the chainDir:
+- `research.md`
+- `gh-context.md`
+- `linear-context.md`
+- `env-context.md`
+
+If **all 4 files exist**, skip to Step 2 — reuse cached research.
+
+If **any are missing**, run only the missing research agents in parallel:
 
 ```json
 {
@@ -37,19 +45,18 @@ Run all 4 research agents in parallel to gather external context:
 }
 ```
 
-Note the `chainDir` returned — all subsequent steps must use the same `chainDir`.
+Only include tasks for agents whose output files are missing. Drop the rest.
+
+Note the `chainDir` returned — use the same `chainDir` for Step 2.
 
 ## Step 2 — Scout, plan, and challenge
 
-Run the plan chain using the same `chainDir` from Step 1:
+Run the plan chain using the same `chainDir`:
 
 ```json
 {
-  "chain": [
-    { "agent": "scout", "task": "Analyze the codebase for: $@\n\nRead the research artifacts from {chain_dir} for additional context.", "output": "context.md", "reads": ["research.md", "gh-context.md", "linear-context.md", "env-context.md"] },
-    { "agent": "planner", "task": "Create an implementation plan. Primary input: {chain_dir}/context.md. Raw research files are available in {chain_dir} if you need to verify details.", "output": "plan.md", "reads": ["context.md"] },
-    { "agent": "oracle", "task": "Review the plan. Challenge assumptions. Check for drift. Report: diagnosis, drift check, recommendation, risks.", "output": "oracle-verdict.md", "reads": ["plan.md", "context.md"] }
-  ],
+  "chain": "plan",
+  "task": "$@",
   "chainDir": "<chainDir from Step 1>"
 }
 ```


### PR DESCRIPTION

 ## Why

 The `/plan` and `/implement` chains had inefficiencies: redundant file reads across agents, unused research agents, no caching of research artifacts between re-runs, and manual orchestration where a single chain
 call would suffice.

 ## Approach

 Incremental improvements across both chains rather than a rewrite. Each commit targets one specific inefficiency. Kept conditional logic (background mode, plan reuse, review-only) in the prompt template since
 chain definitions are declarative and can't express conditionals.

 ## How it works

 **Plan chain:**
 - Planner reads only `context.md` instead of re-reading all 4 research files that scout already distilled. Raw files remain available on demand.
 - Oracle now reads `research.md` to cross-check plan claims against sources.
 - Research agents run conditionally — only when their output files are missing from `chainDir`. Subsequent `/plan` calls reuse cached artifacts.

 **Implement chain:**
 - Chain definition now includes parallel reviewers (3×, concurrency 3) — standard mode invokes the chain directly instead of 4 manual subagent calls.
 - Reviewers read `plan.md` (if available) to catch implementation drift from prior `/plan`.
 - Worker references research artifacts from `chainDir` when available.
 - Non-blocker reviewer fixes are auto-applied without a user round-trip. Blockers still gate on user confirmation.