### PR TITLE
Fix plan and implement prompts to route artifacts via chainDir

### DIFF
--- a/templates/pi/prompts/implement.md
+++ b/templates/pi/prompts/implement.md
@@ -37,26 +37,26 @@ Check the user's request:
 Check session state for a prior plan chain run:
 
 - **Prior plan chain ran in this session** — reuse its `chainDir`:
-  1. Skip the implement chain. Run worker directly with `plan.md` and `context.md` from that `chainDir`.
-  2. Research artifacts (`research.md`, `gh-context.md`, `linear-context.md`, `env-context.md`) are available in the same `chainDir` — pass them to worker for additional context.
-  3. After worker completes, run parallel reviewers (Step 4) using the same `chainDir`.
-  4. Go to Step 5.
+  1. Skip context-builder.
+  2. Worker reads existing `plan.md` and `context.md` from that `chainDir`.
+  3. Go to Step 3.
 
-- **No prior context** — run the implement chain:
+- **No prior context**:
+  1. Run context-builder (Step 2A), then continue to Step 3.
+
+### Step 2A — Context building
 
 ```json
 {
-  "chain": "implement",
-  "task": "$@"
+  "agent": "context-builder",
+  "task": "Analyze the codebase for: $@",
+  "chainDir": "<chainDir from Step 0>"
 }
 ```
 
-The chain runs: context-builder → worker → 3 parallel reviewers.
-Go to Step 5.
+Outputs: `context.md`, `meta-prompt.md` in `{chain_dir}`.
 
-## Step 3 — Implementation (background/plan-reuse mode only)
-
-Only used when skipping the chain (background mode or prior plan reuse).
+## Step 3 — Implementation
 
 ```json
 {
@@ -70,26 +70,26 @@ Only used when skipping the chain (background mode or prior plan reuse).
 Worker reads: `context.md`, `meta-prompt.md` (or `plan.md` if from a prior plan chain).
 Output: `progress.md` in `chainDir`.
 
-## Step 4 — Parallel review (background/plan-reuse/review-only mode)
+## Step 4 — Parallel review
 
-Only used when not running the full implement chain (chain includes reviewers).
+Run three reviewers in parallel. Each must **not** edit files — report findings only.
 
 ```json
 {
   "tasks": [
     {
       "agent": "reviewer",
-      "task": "Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints. Do not edit files. Report: Correct → Blocker → Note.",
       "output": "review-correctness.md"
     },
     {
       "agent": "reviewer",
-      "task": "Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints. Do not edit files. Report: Correct → Blocker → Note.",
       "output": "review-tests.md"
     },
     {
       "agent": "reviewer",
-      "task": "Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints. Do not edit files. Report: Correct → Blocker → Note.",
       "output": "review-cleanup.md"
     }
   ],
@@ -100,31 +100,26 @@ Only used when not running the full implement chain (chain includes reviewers).
 
 Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md` from `chainDir`.
 
-## Step 5 — Apply fixes and present findings
+## Step 5 — Present findings
 
-After reviewers complete:
+After reviewers complete, present to the user:
 
-1. **If blockers found** — stop and present to the user:
-   - Summary of what worker implemented (from `progress.md`).
-   - Blockers that need user decision.
-   - Paths to all artifacts.
-   - **Wait for user confirmation before applying any fixes.**
+1. Summary of what worker implemented (from `progress.md`).
+2. Key findings per reviewer — blockers first, then fixes, then notes.
+3. Paths to all artifacts: `context.md`, `meta-prompt.md`, `progress.md`, `review-correctness.md`, `review-tests.md`, `review-cleanup.md`.
 
-2. **If no blockers** — auto-apply non-blocker fixes:
+**Stop and wait for user confirmation before proceeding to Step 6.**
+
+## Step 6 — Apply fixes (only after user confirms)
 
 ```json
 {
   "agent": "worker",
-  "task": "Apply the reviewer fixes. Skip suggestions that conflict with meta-prompt constraints or expand scope. Report what was applied vs skipped with rationale.",
+  "task": "Apply the reviewer fixes that make sense. Skip suggestions that conflict with meta-prompt constraints or expand scope. Report what was applied vs skipped with rationale.",
   "chainDir": "<chainDir from Step 0>"
 }
 ```
 
-Worker reads: `review-correctness.md`, `review-tests.md`, `review-cleanup.md`, `context.md`.
-
-Then present:
-   - Summary of what worker implemented and what fixes were applied.
-   - Key findings per reviewer — notes and suggestions that were skipped.
-   - Paths to all artifacts: `context.md`, `meta-prompt.md`, `progress.md`, `review-correctness.md`, `review-tests.md`, `review-cleanup.md`.
+Worker reads: `review-correctness.md`, `review-tests.md`, `review-cleanup.md`, `context.md` from `chainDir`.
 
 <!-- {{ ansible_managed }} --->

--- a/templates/pi/prompts/implement.md
+++ b/templates/pi/prompts/implement.md
@@ -5,15 +5,16 @@ description: Implement a task with context building, coding, and parallel review
 
 Implement "$@" by following the decision tree below. Execute each step using the subagent tool.
 
-## Step 0 — Pick a chainDir
+## Step 0 — Establish chainDir
 
-Before anything else, choose a stable shared directory for all artifacts in this session:
+- **Prior `/plan` ran in this session** — reuse its `chainDir`. All research and plan artifacts are already there.
+- **No prior plan** — compute a new one:
 
+```bash
+echo "$HOME/.pi/agent/sessions/--$(pwd | sed 's|^/||' | tr '/' '-')--/chain-runs/<slug>"
 ```
-chainDir = /tmp/implement-<slug>-<YYYYMMDD>
-```
 
-Use this same `chainDir` on **every** subagent call below. This keeps all output files out of the repo working tree.
+Replace `<slug>` with a short kebab-case label for the task. Use this same `chainDir` on **every** subagent call below.
 
 ## Step 1 — Determine execution mode
 

--- a/templates/pi/prompts/implement.md
+++ b/templates/pi/prompts/implement.md
@@ -5,12 +5,22 @@ description: Implement a task with context building, coding, and parallel review
 
 Implement "$@" by following the decision tree below. Execute each step using the subagent tool.
 
+## Step 0 — Pick a chainDir
+
+Before anything else, choose a stable shared directory for all artifacts in this session:
+
+```
+chainDir = /tmp/implement-<slug>-<YYYYMMDD>
+```
+
+Use this same `chainDir` on **every** subagent call below. This keeps all output files out of the repo working tree.
+
 ## Step 1 — Determine execution mode
 
 Check the user's request:
 
 - **Background mode** — user says "background", "bg", or "if blocked, ask me":
-  1. Run worker only (Step 3) with `async: true`.
+  1. Run worker only (Step 3) with `async: true` and the chosen `chainDir`.
   2. Worker escalates blocked decisions via `contact_supervisor`.
   3. After worker completes, notify the user and offer to run reviewers (Step 4).
   4. Stop here until user responds.
@@ -51,13 +61,14 @@ Only used when skipping the chain (background mode or prior plan reuse).
 ```json
 {
   "agent": "worker",
-  "task": "Implement the task using context and meta-prompt. Escalate unapproved decisions via contact_supervisor. No placeholders, no TODOs, no silent scope changes."
+  "task": "Implement the task using context and meta-prompt. Escalate unapproved decisions via contact_supervisor. No placeholders, no TODOs, no silent scope changes.",
+  "chainDir": "<chainDir from Step 0>",
+  "output": "progress.md"
 }
 ```
 
 Worker reads: `context.md`, `meta-prompt.md` (or `plan.md` if from a prior plan chain).
-If research artifacts exist in `chainDir` (`research.md`, `gh-context.md`, `linear-context.md`, `env-context.md`), worker may reference them for implementation details.
-Output: `progress.md`.
+Output: `progress.md` in `chainDir`.
 
 ## Step 4 — Parallel review (background/plan-reuse/review-only mode)
 
@@ -82,11 +93,12 @@ Only used when not running the full implement chain (chain includes reviewers).
       "output": "review-cleanup.md"
     }
   ],
-  "concurrency": 3
+  "concurrency": 3,
+  "chainDir": "<chainDir from Step 0>"
 }
 ```
 
-Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md`, `plan.md` (if available from prior plan chain).
+Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md` from `chainDir`.
 
 ## Step 5 — Apply fixes and present findings
 
@@ -103,7 +115,8 @@ After reviewers complete:
 ```json
 {
   "agent": "worker",
-  "task": "Apply the reviewer fixes. Skip suggestions that conflict with meta-prompt constraints or expand scope. Report what was applied vs skipped with rationale."
+  "task": "Apply the reviewer fixes. Skip suggestions that conflict with meta-prompt constraints or expand scope. Report what was applied vs skipped with rationale.",
+  "chainDir": "<chainDir from Step 0>"
 }
 ```
 

--- a/templates/pi/prompts/implement.md
+++ b/templates/pi/prompts/implement.md
@@ -79,17 +79,17 @@ Run three reviewers in parallel. Each must **not** edit files — report finding
   "tasks": [
     {
       "agent": "reviewer",
-      "task": "Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints. Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
       "output": "review-correctness.md"
     },
     {
       "agent": "reviewer",
-      "task": "Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints. Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
       "output": "review-tests.md"
     },
     {
       "agent": "reviewer",
-      "task": "Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints. Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
       "output": "review-cleanup.md"
     }
   ],
@@ -98,27 +98,32 @@ Run three reviewers in parallel. Each must **not** edit files — report finding
 }
 ```
 
-Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md` from `chainDir`.
+Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md`, `plan.md` (if available) from `chainDir`.
 
-## Step 5 — Present findings
+## Step 5 — Apply fixes and present findings
 
-After reviewers complete, present to the user:
+After reviewers complete:
 
-1. Summary of what worker implemented (from `progress.md`).
-2. Key findings per reviewer — blockers first, then fixes, then notes.
-3. Paths to all artifacts: `context.md`, `meta-prompt.md`, `progress.md`, `review-correctness.md`, `review-tests.md`, `review-cleanup.md`.
+1. **If blockers found** — stop and present to the user:
+   - Summary of what worker implemented (from `progress.md`).
+   - Blockers that need user decision.
+   - Paths to all artifacts.
+   - **Wait for user confirmation before applying any fixes.**
 
-**Stop and wait for user confirmation before proceeding to Step 6.**
-
-## Step 6 — Apply fixes (only after user confirms)
+2. **If no blockers** — auto-apply non-blocker fixes:
 
 ```json
 {
   "agent": "worker",
-  "task": "Apply the reviewer fixes that make sense. Skip suggestions that conflict with meta-prompt constraints or expand scope. Report what was applied vs skipped with rationale.",
+  "task": "Apply the reviewer fixes. Skip suggestions that conflict with meta-prompt constraints or expand scope. Report what was applied vs skipped with rationale.",
   "chainDir": "<chainDir from Step 0>"
 }
 ```
+
+Then present:
+   - Summary of what worker implemented and what fixes were applied.
+   - Key findings per reviewer — notes and suggestions that were skipped.
+   - Paths to all artifacts: `context.md`, `meta-prompt.md`, `progress.md`, `review-correctness.md`, `review-tests.md`, `review-cleanup.md`.
 
 Worker reads: `review-correctness.md`, `review-tests.md`, `review-cleanup.md`, `context.md` from `chainDir`.
 

--- a/templates/pi/prompts/plan.md
+++ b/templates/pi/prompts/plan.md
@@ -5,6 +5,16 @@ argument-hint: "<task>"
 
 Plan "$@" by following the steps below. Execute each step using the subagent tool.
 
+## Step 0 — Pick a chainDir
+
+Compute a session-scoped directory for all artifacts:
+
+```bash
+echo "$HOME/.pi/agent/sessions/--$(pwd | sed 's|^/||' | tr '/' '-')--/chain-runs/<slug>"
+```
+
+Replace `<slug>` with a short kebab-case label for the task (e.g. `add-nr-skill`). Use this same `chainDir` on every subagent call below — it keeps artifacts out of the repo working tree and co-located with session history.
+
 ## Step 1 — Conditional research
 
 Check if these research artifacts already exist in the chainDir:
@@ -42,7 +52,7 @@ If **any are missing**, run only the missing research agents in parallel:
     }
   ],
   "concurrency": 4,
-  "chainDir": "<pick a stable shared path, e.g. /tmp/plan-$@-YYYYMMDD>"
+  "chainDir": "<chainDir from Step 0>"
 }
 ```
 

--- a/templates/pi/prompts/plan.md
+++ b/templates/pi/prompts/plan.md
@@ -41,13 +41,14 @@ If **any are missing**, run only the missing research agents in parallel:
       "output": "env-context.md"
     }
   ],
-  "concurrency": 4
+  "concurrency": 4,
+  "chainDir": "<pick a stable shared path, e.g. /tmp/plan-$@-YYYYMMDD>"
 }
 ```
 
 Only include tasks for agents whose output files are missing. Drop the rest.
 
-Note the `chainDir` returned — use the same `chainDir` for Step 2.
+Note the `chainDir` used — all subsequent steps must reuse the exact same value.
 
 ## Step 2 — Scout, plan, and challenge
 


### PR DESCRIPTION

   ## Why

   Subagent output files (`progress.md`, `research.md`, `review-*.md`, etc.) were written to
   the repo working tree root instead of a dedicated temp directory. This polluted `git status`
   and made subsequent Git operations noisy. A secondary issue: parallel research tasks in the
   `/plan` prompt saved outputs with auto-generated prefixed filenames
   (`c43cb4e6_researcher_0_output.md`) instead of the simple names the chain's `reads` arrays
   expected (`research.md`), so the planner and oracle couldn't find them without manual path
   mapping.

   Both problems had the same root cause: no `chainDir` was established or threaded through the
   subagent calls.

   ## Approach

   Rather than patching individual calls, the implement prompt was restructured to drop the
   opaque `"chain": "implement"` black-box invocation and replace it with explicit Steps 0–6
   where each subagent call carries the same `chainDir`. This makes artifact routing visible and
   consistent across all execution modes (standard, background, plan-reuse, review-only).

   The plan prompt received a targeted fix: `chainDir` added to the parallel research block so
   output filenames match what Step 2's chain reads expect.

   ## How it works

   - **`templates/pi/prompts/implement.md`** — adds Step 0 to pick a stable `chainDir`
     (`/tmp/implement-<slug>-<YYYYMMDD>`); threads it through context-builder (Step 2A), worker
     (Step 3), reviewers (Step 4), and fix worker (Step 6); removes the `"chain": "implement"`
     path that had no `chainDir`
   - **`templates/pi/prompts/plan.md`** — adds `chainDir` to the parallel research block so
     `output: "research.md"` saves to `{chainDir}/research.md` and the scout/planner/oracle
     chain resolves `reads: ["research.md"]` correctly