### PR TITLE
Set Kitty font to Iosevka Term

### DIFF
--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -6,7 +6,7 @@
 # --------------------
 # Font configuration
 # --------------------
-font_family      Iosevka
+font_family      Iosevka Term
 bold_font        auto
 italic_font      auto
 bold_italic_font auto

--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -6,7 +6,7 @@
 # --------------------
 # Font configuration
 # --------------------
-font_family      Fira Code
+font_family      Iosevka
 bold_font        auto
 italic_font      auto
 bold_italic_font auto


### PR DESCRIPTION
## Why

Use Iosevka Term as the Kitty terminal font on the home laptop.

## Approach

Update the committed Kitty config template directly so Ansible deploys the new font through the existing config copy flow.

## How it works

Changes `templates/kitty.conf` to set `font_family` from `Fira Code` to `Iosevka Term`. Bold, italic, and bold italic fonts remain `auto`.

## Links

- None
