### PR TITLE
Fix Kitty font by removing duplicate font_family overrides

### DIFF
--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -6,14 +6,13 @@
 # --------------------
 # Font configuration
 # --------------------
-font_family      Iosevka Term
+font_family      family='Iosevka Term' postscript_name=Iosevka-Term
 bold_font        auto
 italic_font      auto
 bold_italic_font auto
 
-# Fallback fonts
-font_family      JetBrains Mono
-font_family      Symbols Nerd Font Mono
+# Nerd Font symbols fallback
+symbol_map U+E000-U+F8FF,U+F0000-U+FFFFF Symbols Nerd Font Mono
 
 font_size 13
 


### PR DESCRIPTION
## Why

Kitty should use Iosevka Term as the primary font. Duplicate `font_family` fallback declarations override that setting with Symbols Nerd Font Mono.

## Approach

Replace the bogus fallback `font_family` declarations with `symbol_map` entries. This preserves Nerd Font glyph coverage without changing the primary font.

## How it works

Updates `templates/kitty.conf` so Iosevka Term remains the configured `font_family`, while symbol ranges are mapped to Symbols Nerd Font Mono through Kitty's `symbol_map` directive.

## Links

- PR: https://github.com/boga/dotfiles/pull/76
