### PR TITLE
Add Iosevka font cask

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -53,6 +53,7 @@ homebrew_casks:
   - finetune
   - font-fira-code
   - font-hack-nerd-font
+  - font-iosevka
   - font-monaspace
   - font-sf-mono
   - keepingyouawake


### PR DESCRIPTION
## Why

Iosevka is now used by the terminal configuration, so the setup playbook should install the font on fresh machines.

## Approach

Add the Homebrew cask to the shared cask list alongside the other font casks.

## How it works

`homebrew_casks` now includes `font-iosevka`, so the existing Homebrew cask task installs it during workstation setup.

## Links

- None
