### PR TITLE
Bump Claude Opus 4.6 to 4.8 for work host

### DIFF
--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -6,7 +6,7 @@ firefox_profile_dir: /Users/ivan-shnurchenko/Library/Application Support/Firefox
 
 pi_plannotator_planning_model:
   provider: "anthropic"
-  id: "claude-opus-4-6"
+  id: "claude-opus-4-8"
 pi_plannotator_planning_thinking: "xhigh"
 pi_plannotator_executing_model:
   provider: "anthropic"
@@ -14,7 +14,7 @@ pi_plannotator_executing_model:
 pi_plannotator_executing_thinking: "medium"
 pi_plannotator_reviewing_model:
   provider: "anthropic"
-  id: "claude-opus-4-6"
+  id: "claude-opus-4-8"
 pi_plannotator_reviewing_thinking: "xhigh"
 
 pi_agent_subagent_overrides:
@@ -31,15 +31,15 @@ pi_agent_subagent_overrides:
       linear-researcher:
         thinking: "low"
       oracle:
-        model: "anthropic/claude-opus-4-6"
+        model: "anthropic/claude-opus-4-8"
         thinking: "high"
       planner:
-        model: "anthropic/claude-opus-4-6"
+        model: "anthropic/claude-opus-4-8"
         thinking: "xhigh"
       researcher:
         thinking: "medium"
       reviewer:
-        model: "anthropic/claude-opus-4-6"
+        model: "anthropic/claude-opus-4-8"
         thinking: "high"
       scout:
         model: "anthropic/claude-sonnet-4-6"


### PR DESCRIPTION
## Why

Keep the work-host pi configuration on the newer Claude Opus 4.8 model.

## Approach

Update the work host variable values directly so generated pi configuration continues to use host-specific overrides.

## How it works

Changes `host_vars/work/vars.yml` to point the planning, Plannotator execution, and subagent override model IDs from Claude Opus 4.6 to Claude Opus 4.8.

## Links

- None