### PR TITLE
Mise: trust ~/Work recursively instead of broken glob

### DIFF
--- a/templates/mise.toml
+++ b/templates/mise.toml
@@ -1,5 +1,5 @@
 [settings]
-trusted_config_paths = ["~/Work/**"]
+trusted_config_paths = ["~/Work"]
 
 [env]
 _.path = "/Applications/IntelliJ IDEA.app/Contents/MacOS"


### PR DESCRIPTION
trusted_config_paths uses prefix matching, not glob, so the literal "~/Work/**" never matched. New git worktrees under ~/Work were untrusted. A plain directory entry trusts everything beneath it.