### PR TITLE
Add n8n MCP server to the work host Pi agent

### DIFF
--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -63,6 +63,14 @@ pi_agent_mcp_servers:
     headers:
       Api-Key: "${NEW_RELIC_MCP_API_KEY}"
       include-tags: "discovery,data-access,alerting,incident-response,performance-analytics,advanced-analysis"
+  n8n:
+    type: "http"
+    url: "https://dev-n8n-server.api-swap-os.com/mcp"
+    # OAuth 2.1 with dynamic client registration. The adapter auto-discovers
+    # the authorization server (https://dev-n8n-server.api-swap-os.com/mcp-server/http)
+    # via the server's WWW-Authenticate / protected-resource metadata.
+    # Run `/mcp-auth n8n` in Pi to complete the browser auth flow.
+    auth: "oauth"
 
 # Work-specific packages, appended to the global pi_agent_settings_packages list
 pi_agent_settings_extra_packages:

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -65,10 +65,10 @@ pi_agent_mcp_servers:
       include-tags: "discovery,data-access,alerting,incident-response,performance-analytics,advanced-analysis"
   n8n:
     type: "http"
-    url: "https://dev-n8n-server.api-swap-os.com/mcp"
+    url: "https://dev-n8n-server.api-swap-os.com/mcp-server/http"
     # OAuth 2.1 with dynamic client registration. The adapter auto-discovers
-    # the authorization server (https://dev-n8n-server.api-swap-os.com/mcp-server/http)
-    # via the server's WWW-Authenticate / protected-resource metadata.
+    # the authorization server from the endpoint's WWW-Authenticate /
+    # protected-resource metadata, so no static secret is stored.
     # Run `/mcp-auth n8n` in Pi to complete the browser auth flow.
     auth: "oauth"
 


### PR DESCRIPTION
   ## Why

   The work Pi agent had no access to our dev n8n instance. Wiring it in as an
   MCP server lets the agent search workflows, projects, executions, and
   credentials directly from Pi.

   ## How

   - Add an `n8n` entry to `pi_agent_mcp_servers` in `host_vars/work/vars.yml`.
   - Point it at the n8n Streamable HTTP MCP endpoint `/mcp-server/http`
     (per n8n's docs — `/mcp` returns a non-`text/event-stream` content type
     and fails to connect).
   - Use `type: "http"` with `auth: "oauth"`. OAuth 2.1 with dynamic client
     registration; the adapter auto-discovers the authorization server from the
     endpoint's `WWW-Authenticate` / protected-resource metadata, so no static
     secret is stored.

   ## Notes

   - After applying, run `/mcp-auth n8n` in Pi to complete the browser OAuth flow.
   - Verified live: connection succeeds and `n8n_search_projects` /
     `n8n_search_workflows` return results.

   ## Context

   n8n MCP / OAuth2.1 reference:
   https://docs.n8n.io/advanced-ai/mcp/accessing-n8n-mcp-server/#using-oauth2_1