### PR TITLE
feat(pi_agent): add graphify knowledge-graph skill

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -60,6 +60,10 @@
       ansible.builtin.command: mise upgrade
       changed_when: true
 
+    - name: "Install graphify Pi skill"
+      ansible.builtin.command: mise exec -- python3 -m graphify pi install
+      changed_when: false
+
     - name: "Update Pi extensions"
       ansible.builtin.command: pi update --extensions
       changed_when: true

--- a/templates/mise.toml
+++ b/templates/mise.toml
@@ -7,5 +7,6 @@ _.path = "/Applications/IntelliJ IDEA.app/Contents/MacOS"
 [tools]
 node = "25"
 bun  = "latest"
+python = { version = "3.13", postinstall = "python -m pip install --upgrade graphifyy==0.8.28" }
 "npm:@earendil-works/pi-coding-agent" = "latest"
 "npm:context-mode" = "latest"


### PR DESCRIPTION
Install the graphify engine into a mise-managed Python via a postinstall hook (graphifyy pinned), and register the upstream-maintained Pi skill with `graphify pi install` from a playbook post_task. The install is throttled to run at most once per hour by comparing the skill file's mtime.