### PR TITLE
fix(pi): fix oracle SIGTERM and chain thinking-block errors

### DIFF
--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -33,9 +33,12 @@ pi_agent_subagent_overrides:
       oracle:
         model: "anthropic/claude-opus-4-8"
         thinking: "high"
+        maxExecutionTimeMs: 600000
+        defaultContext: "fresh"
       planner:
         model: "anthropic/claude-opus-4-8"
         thinking: "xhigh"
+        defaultContext: "fresh"
       researcher:
         thinking: "medium"
       reviewer:

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -51,6 +51,7 @@ pi_agent_subagent_overrides:
       worker:
         model: "anthropic/claude-sonnet-4-6"
         thinking: "medium"
+        defaultContext: "fresh"
 
 pi_agent_mcp_servers:
   context-mode:

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -33,12 +33,24 @@ pi_agent_subagent_overrides:
       oracle:
         model: "anthropic/claude-opus-4-8"
         thinking: "high"
+        # 10-minute ceiling for long reasoning passes over large context.
+        # Note: does not extend any API-level streaming limit — only caps
+        # pi-subagents' own resource-limit timer.
         maxExecutionTimeMs: 600000
+        # Must be "fresh" — oracle ships defaultContext: fork, which promotes
+        # the entire plan chain (scout→planner→oracle) to context: fork.
+        # A forked chain inherits the parent session's thinking blocks;
+        # Anthropic rejects those with HTTP 400. Fresh context is safe because
+        # oracle receives all it needs via reads: (plan.md, context.md, research.md).
         defaultContext: "fresh"
       planner:
         model: "anthropic/claude-opus-4-8"
         thinking: "xhigh"
+        # Same ceiling as oracle; planner uses xhigh thinking which runs longer.
         maxExecutionTimeMs: 600000
+        # Same chain-fork guard as oracle — planner appears in both plan and
+        # implement chains; fork promotion from either would re-expose it to
+        # the thinking-block API 400.
         defaultContext: "fresh"
       researcher:
         thinking: "medium"
@@ -51,6 +63,11 @@ pi_agent_subagent_overrides:
       worker:
         model: "anthropic/claude-sonnet-4-6"
         thinking: "medium"
+        # worker ships defaultContext: fork (continue-the-thread intent).
+        # In the implement chain (context-builder→worker→reviewer×3) this
+        # promotes ALL steps to context: fork, which causes Anthropic HTTP 400
+        # when the parent session has thinking blocks. worker gets everything
+        # it needs from reads: (context.md, meta-prompt.md), so fresh is safe.
         defaultContext: "fresh"
 
 pi_agent_mcp_servers:

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -38,6 +38,7 @@ pi_agent_subagent_overrides:
       planner:
         model: "anthropic/claude-opus-4-8"
         thinking: "xhigh"
+        maxExecutionTimeMs: 600000
         defaultContext: "fresh"
       researcher:
         thinking: "medium"

--- a/templates/pi/agents/linear-researcher.agent.md
+++ b/templates/pi/agents/linear-researcher.agent.md
@@ -1,7 +1,7 @@
 ---
 name: linear-researcher
 description: Gathers Linear project context via MCP tools — tickets, milestones, project state, and blockers
-tools: write, intercom
+tools: write, intercom, linear_issue, linear_project, linear_milestone, linear_team
 thinking: low
 systemPromptMode: replace
 inheritProjectContext: false

--- a/templates/pi/agents/linear-researcher.agent.md
+++ b/templates/pi/agents/linear-researcher.agent.md
@@ -1,6 +1,10 @@
 ---
 name: linear-researcher
 description: Gathers Linear project context via MCP tools — tickets, milestones, project state, and blockers
+# Linear MCP tools must be declared explicitly here — pi passes --tools to the child
+# process and only listed tools are available. Without them the agent's system prompt
+# instructs it to call linear_issue/project/milestone/team but those calls silently
+# fail, producing a placeholder output instead of real Linear data.
 tools: write, intercom, linear_issue, linear_project, linear_milestone, linear_team
 thinking: low
 systemPromptMode: replace


### PR DESCRIPTION
- Add maxExecutionTimeMs: 600000 to oracle override to prevent SIGTERM kills on long thinking-heavy API calls (~2min+)
- Add defaultContext: fresh to oracle and planner to prevent context: fork promotion across chain steps, which caused Anthropic API 400 errors when thinking blocks from the parent session leaked into the chain step's initial message history