### PR TITLE
Fix artifact output paths to land in chainDir instead of repo root

### DIFF
--- a/templates/pi/prompts/implement.md
+++ b/templates/pi/prompts/implement.md
@@ -64,7 +64,7 @@ Outputs: `context.md`, `meta-prompt.md` in `{chain_dir}`.
   "agent": "worker",
   "task": "Implement the task using context and meta-prompt. Escalate unapproved decisions via contact_supervisor. No placeholders, no TODOs, no silent scope changes.",
   "chainDir": "<chainDir from Step 0>",
-  "output": "progress.md"
+  "output": "<chainDir from Step 0>/progress.md"
 }
 ```
 
@@ -81,17 +81,17 @@ Run three reviewers in parallel. Each must **not** edit files — report finding
     {
       "agent": "reviewer",
       "task": "Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
-      "output": "review-correctness.md"
+      "output": "<chainDir from Step 0>/review-correctness.md"
     },
     {
       "agent": "reviewer",
       "task": "Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
-      "output": "review-tests.md"
+      "output": "<chainDir from Step 0>/review-tests.md"
     },
     {
       "agent": "reviewer",
       "task": "Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
-      "output": "review-cleanup.md"
+      "output": "<chainDir from Step 0>/review-cleanup.md"
     }
   ],
   "concurrency": 3,

--- a/templates/pi/prompts/plan.md
+++ b/templates/pi/prompts/plan.md
@@ -17,11 +17,11 @@ Replace `<slug>` with a short kebab-case label for the task (e.g. `add-nr-skill`
 
 ## Step 1 — Conditional research
 
-Check if these research artifacts already exist in the chainDir:
-- `research.md`
-- `gh-context.md`
-- `linear-context.md`
-- `env-context.md`
+Check if these research artifacts already exist in the chainDir (use absolute paths, e.g. `<chainDir>/research.md`):
+- `<chainDir>/research.md`
+- `<chainDir>/gh-context.md`
+- `<chainDir>/linear-context.md`
+- `<chainDir>/env-context.md`
 
 If **all 4 files exist**, skip to Step 2 — reuse cached research.
 
@@ -33,22 +33,22 @@ If **any are missing**, run only the missing research agents in parallel:
     {
       "agent": "researcher",
       "task": "Research official docs, specs, benchmarks, and recent changes relevant to: $@\n\nFocus on primary sources. Drop stale or SEO-heavy results. Web research only — use web_search and fetch_content tools. If web tools are unavailable, write research.md noting no external research was available and exit successfully.",
-      "output": "research.md"
+      "output": "<chainDir from Step 0>/research.md"
     },
     {
       "agent": "gh-researcher",
       "task": "Gather GitHub repository state relevant to: $@\n\nFocus on open PRs, related issues, recent CI status, and releases. If gh CLI is unavailable or the repo has no remote, write gh-context.md noting that and exit successfully.",
-      "output": "gh-context.md"
+      "output": "<chainDir from Step 0>/gh-context.md"
     },
     {
       "agent": "linear-researcher",
       "task": "Gather Linear project context relevant to: $@\n\nFocus on related tickets, milestones, blockers, and project status. If Linear is unreachable or no relevant issues exist, write linear-context.md noting that and exit successfully.",
-      "output": "linear-context.md"
+      "output": "<chainDir from Step 0>/linear-context.md"
     },
     {
       "agent": "env-scout",
       "task": "Inventory local environment state relevant to: $@\n\nFocus on tool versions, running services, and package state that matter for the task. If nothing is relevant, write env-context.md noting a clean environment and exit successfully.",
-      "output": "env-context.md"
+      "output": "<chainDir from Step 0>/env-context.md"
     }
   ],
   "concurrency": 4,
@@ -78,6 +78,6 @@ After the chain completes, present:
 1. Full path to plan.md
 2. Key findings from each research source (web, GitHub, Linear, environment)
 3. Oracle verdict and challenged assumptions
-4. Paths to all artifacts (research.md, gh-context.md, linear-context.md, env-context.md, context.md, plan.md, oracle-verdict.md)
+4. Paths to all artifacts in the chainDir (research.md, gh-context.md, linear-context.md, env-context.md, context.md, plan.md, oracle-verdict.md)
 
 <!-- {{ ansible_managed }} --->

--- a/templates/pi/prompts/plan.md
+++ b/templates/pi/prompts/plan.md
@@ -32,22 +32,22 @@ If **any are missing**, run only the missing research agents in parallel:
   "tasks": [
     {
       "agent": "researcher",
-      "task": "Research official docs, specs, benchmarks, and recent changes relevant to: $@\n\nFocus on primary sources. Drop stale or SEO-heavy results. Web research only — use web_search and fetch_content tools. If web tools are unavailable, write research.md noting no external research was available and exit successfully.",
+      "task": "Research official docs, specs, benchmarks, and recent changes relevant to: $@\n\nFocus on primary sources. Drop stale or SEO-heavy results. Web research only — use web_search and fetch_content tools. If web tools are unavailable, write <chainDir from Step 0>/research.md noting no external research was available and exit successfully.",
       "output": "<chainDir from Step 0>/research.md"
     },
     {
       "agent": "gh-researcher",
-      "task": "Gather GitHub repository state relevant to: $@\n\nFocus on open PRs, related issues, recent CI status, and releases. If gh CLI is unavailable or the repo has no remote, write gh-context.md noting that and exit successfully.",
+      "task": "Gather GitHub repository state relevant to: $@\n\nFocus on open PRs, related issues, recent CI status, and releases. If gh CLI is unavailable or the repo has no remote, write <chainDir from Step 0>/gh-context.md noting that and exit successfully.",
       "output": "<chainDir from Step 0>/gh-context.md"
     },
     {
       "agent": "linear-researcher",
-      "task": "Gather Linear project context relevant to: $@\n\nFocus on related tickets, milestones, blockers, and project status. If Linear is unreachable or no relevant issues exist, write linear-context.md noting that and exit successfully.",
+      "task": "Gather Linear project context relevant to: $@\n\nFocus on related tickets, milestones, blockers, and project status. If Linear is unreachable or no relevant issues exist, write <chainDir from Step 0>/linear-context.md noting that and exit successfully.",
       "output": "<chainDir from Step 0>/linear-context.md"
     },
     {
       "agent": "env-scout",
-      "task": "Inventory local environment state relevant to: $@\n\nFocus on tool versions, running services, and package state that matter for the task. If nothing is relevant, write env-context.md noting a clean environment and exit successfully.",
+      "task": "Inventory local environment state relevant to: $@\n\nFocus on tool versions, running services, and package state that matter for the task. If nothing is relevant, write <chainDir from Step 0>/env-context.md noting a clean environment and exit successfully.",
       "output": "<chainDir from Step 0>/env-context.md"
     }
   ],


### PR DESCRIPTION


   ## Why

   The `/plan` and `/implement` prompt templates instruct subagents to write
   research and review artifacts with bare filenames (`research.md`,
   `progress.md`, `review-*.md`, etc.). The subagent runner resolves bare
   `output` paths relative to `cwd` — not `chainDir` — so every run drops
   these files into the repo working tree, polluting it with unversioned
   scratch files.

   ## Approach

   Make every `output` field in parallel and single subagent calls an
   absolute path by prefixing the computed `chainDir`. This is the only
   correct mechanism: chain-mode steps resolve `output` against `chainDir`,
   but parallel/single mode does not (confirmed in pi source:
   `single-output.ts` / `chain-execution.ts`). No change to chain-step
   calls — those already resolve correctly.

   Also fixed the fallback prose inside each `task:` string (e.g. "write
   research.md") to use the absolute path, preventing literal-minded agents
   from dropping a second stray copy in cwd.

   ## How it works

   - **`plan.md` Step 1** — all four `output` fields and their fallback
     write-target strings now carry `<chainDir from Step 0>/` prefix.
   - **`plan.md` Step 1** — existence check updated to use absolute paths
     so the cache-hit logic works correctly.
   - **`implement.md` Step 3** — worker `output: progress.md` →
     `<chainDir from Step 0>/progress.md`.
   - **`implement.md` Step 4** — all three reviewer outputs
     (`review-correctness.md`, `review-tests.md`, `review-cleanup.md`)
     made absolute.

   Chain calls (`plan.md` Step 2, `implement.md` Step 2A) are unchanged —
   they have no `output` field and already route artifacts through chainDir
   correctly.