### PR TITLE
Add CodeRabbit CLI and integrate it into /implement workflow

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -8,14 +8,15 @@ homebrew_taps:
   - jesseduffield/lazygit
 
 homebrew_packages:
+  - 1password-cli
   - ack
   - act
   - anomalyco/tap/opencode
   - ansible
   - ansible-lint
-  - 1password-cli
   - bat
   - btop
+  - coderabbit
   - dust
   - eza
   - fd
@@ -47,7 +48,6 @@ homebrew_packages:
   - zoxide
   - zsh
   - zsh-history-substring-search
-  - coderabbit
 
 homebrew_casks:
   - alt-tab

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -49,6 +49,7 @@ homebrew_packages:
   - zsh-history-substring-search
 
 homebrew_casks:
+  - coderabbit
   - alt-tab
   - finetune
   - font-fira-code
@@ -191,6 +192,9 @@ config_files:
   - name: "Pi agent: env-scout"
     src: "./templates/pi/agents/env-scout.agent.md"
     dest: "~/.pi/agent/agents/env-scout.agent.md"
+  - name: "Pi skill: coderabbit"
+    src: "./templates/pi/skills/coderabbit/SKILL.md"
+    dest: "~/.pi/agent/skills/coderabbit/SKILL.md"
 
 pi_agent_settings_path: "~/.pi/agent/settings.json"
 pi_agent_settings_overrides: |-

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -47,9 +47,9 @@ homebrew_packages:
   - zoxide
   - zsh
   - zsh-history-substring-search
+  - coderabbit
 
 homebrew_casks:
-  - coderabbit
   - alt-tab
   - finetune
   - font-fira-code

--- a/templates/pi/AGENTS.md
+++ b/templates/pi/AGENTS.md
@@ -38,6 +38,15 @@ When the user references a specific file (e.g. `@AGENTS.md`, `src/foo.ts`), oper
 
 Do **not** use `find` or glob patterns to discover and act on other files with the same name. If you notice other related files that might also need the same change, **ask the user first** before touching them.
 
+## CodeRabbit Policy
+
+Run `cr` (CodeRabbit CLI) **only** in two situations:
+
+1. During `/implement` — as Step 3.5, after the worker and before the Pi reviewers.
+2. When the user explicitly says so: "Use CR" or "Ask CodeRabbit".
+
+Never invoke `cr` spontaneously during planning, exploration, or general code review.
+
 ---
 
 ## context-mode — MANDATORY routing rules

--- a/templates/pi/chains/implement.chain.md
+++ b/templates/pi/chains/implement.chain.md
@@ -22,25 +22,30 @@ If research artifacts exist in {chain_dir} (research.md, gh-context.md, linear-c
 
 Follow meta-prompt constraints exactly. Escalate unapproved decisions via `contact_supervisor` — do not guess or assume. No placeholders, no TODOs, no silent scope changes.
 
+## delegate
+output: review-coderabbit.md
+
+Detect the repo default branch: run `git symbolic-ref refs/remotes/origin/HEAD | sed 's|.*/||'`. Then run `cr review --plain --base <detected-branch> > {chain_dir}/review-coderabbit.md 2>&1`. If cr is not found or exits non-zero, write `WARNING: CodeRabbit review skipped — cr not available or failed.` to `{chain_dir}/review-coderabbit.md` and exit 0.
+
 ## parallel
 concurrency: 3
 
 ### reviewer
-reads: progress.md, context.md, meta-prompt.md, plan.md
+reads: progress.md, context.md, meta-prompt.md, plan.md, review-coderabbit.md
 output: review-correctness.md
 
-Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.
+If `review-coderabbit.md` exists, CodeRabbit (CR) has already reviewed code-quality issues there — do not re-flag CR's code-quality findings. Assess intent and requirements alignment independently, including intent-level issues even if CR flagged a symptom, since CR cannot read plan.md or meta-prompt.md. Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.
 
 ### reviewer
-reads: progress.md, context.md, meta-prompt.md, plan.md
+reads: progress.md, context.md, meta-prompt.md, plan.md, review-coderabbit.md
 output: review-tests.md
 
-Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.
+If `review-coderabbit.md` exists, CodeRabbit (CR) has already reviewed code-quality issues there — do not re-flag CR's code-quality findings. Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.
 
 ### reviewer
-reads: progress.md, context.md, meta-prompt.md, plan.md
+reads: progress.md, context.md, meta-prompt.md, plan.md, review-coderabbit.md
 output: review-cleanup.md
 
-Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.
+If `review-coderabbit.md` exists, CodeRabbit (CR) has already reviewed code-quality issues there — do not re-flag CR's code-quality findings. Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.
 
 <!-- {{ ansible_managed }} --->

--- a/templates/pi/prompts/implement.md
+++ b/templates/pi/prompts/implement.md
@@ -71,6 +71,20 @@ Outputs: `context.md`, `meta-prompt.md` in `{chain_dir}`.
 Worker reads: `context.md`, `meta-prompt.md` (or `plan.md` if from a prior plan chain).
 Output: `progress.md` in `chainDir`.
 
+## Step 3.5 — CodeRabbit review
+
+*Skip in review-only and background modes (Step 1 gates those paths).*
+
+```json
+{
+  "agent": "delegate",
+  "task": "Detect the repo default branch: run `git symbolic-ref refs/remotes/origin/HEAD | sed 's|.*/||'`. Then run `cr review --plain --base <detected-branch> > <chainDir>/review-coderabbit.md 2>&1`. If cr is not found or exits non-zero, write `WARNING: CodeRabbit review skipped — cr not available or failed.` to `<chainDir>/review-coderabbit.md` and exit 0.",
+  "chainDir": "<chainDir from Step 0>"
+}
+```
+
+Output: `review-coderabbit.md` in `chainDir` (always written — warning line on failure).
+
 ## Step 4 — Parallel review
 
 Run three reviewers in parallel. Each must **not** edit files — report findings only.
@@ -80,17 +94,17 @@ Run three reviewers in parallel. Each must **not** edit files — report finding
   "tasks": [
     {
       "agent": "reviewer",
-      "task": "Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "If `review-coderabbit.md` exists in chainDir, CodeRabbit (CR) has already reviewed code-quality issues there — do not re-flag CR's code-quality findings. Assess intent and requirements alignment independently, including intent-level issues even if CR flagged a symptom, since CR cannot read plan.md or meta-prompt.md. Review the implementation for CORRECTNESS and FEASIBILITY. Are the changes sound and logically complete? Do they match the requirements? Any missing steps or broken assumptions? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
       "output": "<chainDir from Step 0>/review-correctness.md"
     },
     {
       "agent": "reviewer",
-      "task": "Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "If `review-coderabbit.md` exists in chainDir, CodeRabbit (CR) has already reviewed code-quality issues there — do not re-flag CR's code-quality findings. Review the implementation for TEST COVERAGE and EDGE CASES. Are there gaps in validation or untested paths? Are edge cases handled? Is error handling adequate? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
       "output": "<chainDir from Step 0>/review-tests.md"
     },
     {
       "agent": "reviewer",
-      "task": "Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
+      "task": "If `review-coderabbit.md` exists in chainDir, CodeRabbit (CR) has already reviewed code-quality issues there — do not re-flag CR's code-quality findings. Review the implementation for CLEANUP and SIMPLICITY. Is there unnecessary complexity? Dead code, poor naming, or redundant logic? Simpler alternatives? Check against meta-prompt.md constraints and plan.md (if available). Do not edit files. Report: Correct → Blocker → Note.",
       "output": "<chainDir from Step 0>/review-cleanup.md"
     }
   ],
@@ -99,7 +113,7 @@ Run three reviewers in parallel. Each must **not** edit files — report finding
 }
 ```
 
-Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md`, `plan.md` (if available) from `chainDir`.
+Each reviewer reads: `progress.md`, `context.md`, `meta-prompt.md`, `plan.md` (if available), `review-coderabbit.md` (if available) from `chainDir`.
 
 ## Step 5 — Apply fixes and present findings
 
@@ -124,7 +138,7 @@ After reviewers complete:
 Then present:
    - Summary of what worker implemented and what fixes were applied.
    - Key findings per reviewer — notes and suggestions that were skipped.
-   - Paths to all artifacts: `context.md`, `meta-prompt.md`, `progress.md`, `review-correctness.md`, `review-tests.md`, `review-cleanup.md`.
+   - Paths to all artifacts: `context.md`, `meta-prompt.md`, `progress.md`, `review-coderabbit.md` (if present), `review-correctness.md`, `review-tests.md`, `review-cleanup.md`.
 
 Worker reads: `review-correctness.md`, `review-tests.md`, `review-cleanup.md`, `context.md` from `chainDir`.
 

--- a/templates/pi/skills/coderabbit/SKILL.md
+++ b/templates/pi/skills/coderabbit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coderabbit
-description: Review code changes using the CodeRabbit CLI (`cr`). Use this skill when reviewing uncommitted changes, staged changes, or committed branch changes before a PR. Triggers on "review my code", "run coderabbit", "cr review", "review changes", or "code review with coderabbit".
+description: Run a CodeRabbit CLI (`cr`) code review. Use this skill only when the user explicitly says "Use CR", "Ask CodeRabbit", or during /implement (Step 3.5). Do not trigger on general review phrases.
 ---
 
 # CodeRabbit CLI

--- a/templates/pi/skills/coderabbit/SKILL.md
+++ b/templates/pi/skills/coderabbit/SKILL.md
@@ -7,16 +7,6 @@ description: Review code changes using the CodeRabbit CLI (`cr`). Use this skill
 
 The CodeRabbit CLI binary is `cr` (`coderabbit` is an alias — both work identically).
 
-## Authentication
-
-One-time setup:
-
-```bash
-cr auth login     # opens browser; sign in to CodeRabbit
-cr auth org       # switch default organization (if multiple orgs)
-cr auth status    # inspect current auth state
-```
-
 ## Review commands
 
 ```bash

--- a/templates/pi/skills/coderabbit/SKILL.md
+++ b/templates/pi/skills/coderabbit/SKILL.md
@@ -55,6 +55,15 @@ cr review uncommitted
 cr review committed --base main
 ```
 
+## Output modes
+
+```bash
+cr review --plain --base main   # readable text output (default for human/LLM consumption)
+cr review --agent --base main   # structured JSON output (for machine parsing)
+```
+
+Prefer `--plain` when the output will be read by a person or an LLM. Use `--agent` only when a script needs to parse status or findings count.
+
 ## Tips
 
 - Must run from inside a Git repository (`--dir` flag overrides the directory)

--- a/templates/pi/skills/coderabbit/SKILL.md
+++ b/templates/pi/skills/coderabbit/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: coderabbit
+description: Review code changes using the CodeRabbit CLI (`cr`). Use this skill when reviewing uncommitted changes, staged changes, or committed branch changes before a PR. Triggers on "review my code", "run coderabbit", "cr review", "review changes", or "code review with coderabbit".
+---
+
+# CodeRabbit CLI
+
+The CodeRabbit CLI binary is `cr` (`coderabbit` is an alias — both work identically).
+
+## Authentication
+
+One-time setup:
+
+```bash
+cr auth login     # opens browser; sign in to CodeRabbit
+cr auth org       # switch default organization (if multiple orgs)
+cr auth status    # inspect current auth state
+```
+
+## Review commands
+
+```bash
+# Review all local changes vs base branch (default: main)
+cr
+
+# Review only uncommitted changes (staged + unstaged)
+cr review uncommitted
+
+# Review only committed changes (branch commits vs base)
+cr review committed
+
+# Specify a non-default base branch
+cr review --base master
+cr review --base develop
+
+# Combine scope and base branch
+cr review uncommitted --base master
+cr review committed --base develop
+```
+
+## Workflow
+
+### Review current branch before opening a PR
+
+```bash
+# 1. Confirm what will be reviewed
+git status
+git diff origin/main...HEAD --stat
+
+# 2. Run the review
+cr                   # all changes vs main
+cr --base master     # if default branch is master, not main
+```
+
+### Review only staged changes
+
+```bash
+git add <files>
+cr review uncommitted
+```
+
+### Review committed work on the branch
+
+```bash
+cr review committed --base main
+```
+
+## Tips
+
+- Must run from inside a Git repository (`--dir` flag overrides the directory)
+- Reviews stream results to the terminal as they complete
+- Review duration: 7–30+ minutes depending on scope
+- `cr` and `coderabbit` are interchangeable — prefer `cr` for brevity


### PR DESCRIPTION


   ## Why

   CodeRabbit CLI provides automated AI code review (bugs, logic errors, race conditions, security) that complements Pi's built-in reviewer subagents. Without a
 clear integration policy, both would flag the same diff independently — contradictory feedback and fix loops.

   ## Approach

   CR is installed via Homebrew and fires in exactly two situations: automatically as Step 3.5 in `/implement`, and on explicit user request ("Use CR", "Ask
 CodeRabbit"). This keeps CR as the code-quality authority while Pi reviewers focus on intent alignment, test coverage, and structural simplicity — lanes that
 CR cannot assess since it has no access to `plan.md` or `meta-prompt.md`.

   Alternatives considered: replacing one Pi reviewer with CR (loses project-context coverage), and running CR as a post-fix gate (two fix rounds, slower). Step
 3.5 was chosen for a clean early quality gate with one fix round.

   ## How it works

   - `group_vars/all.yml`: adds `coderabbit` to `homebrew_packages`
   - `AGENTS.md`: adds a CodeRabbit Policy section enforcing the two-situation rule
   - `prompts/implement.md`: inserts Step 3.5 — a `delegate` subagent that detects the default branch at runtime and runs `cr review --plain --base <branch>`,
 redirecting output to `{chainDir}/review-coderabbit.md`; failure writes a warning and exits 0 (non-fatal)
   - `chains/implement.chain.md`: adds the same `delegate` step; all three reviewers get `review-coderabbit.md` in their reads list and a guard to not re-flag
 CR's code-quality findings
   - `skills/coderabbit/SKILL.md`: documents CR commands, `--plain`/`--agent` output modes, and narrows triggers to explicit-only invocations