### PR TITLE
Replace `cr` alias with `coderabbit` binary name

### DIFF
--- a/templates/pi/AGENTS.md
+++ b/templates/pi/AGENTS.md
@@ -40,12 +40,12 @@ Do **not** use `find` or glob patterns to discover and act on other files with t
 
 ## CodeRabbit Policy
 
-Run `cr` (CodeRabbit CLI) **only** in two situations:
+Run `coderabbit` (CodeRabbit CLI) **only** in two situations:
 
 1. During `/implement` — as Step 3.5, after the worker and before the Pi reviewers.
-2. When the user explicitly says so: "Use CR" or "Ask CodeRabbit".
+2. When the user explicitly says so: "Use CodeRabbit" or "Ask CodeRabbit".
 
-Never invoke `cr` spontaneously during planning, exploration, or general code review.
+Never invoke `coderabbit` spontaneously during planning, exploration, or general code review.
 
 ---
 

--- a/templates/pi/chains/implement.chain.md
+++ b/templates/pi/chains/implement.chain.md
@@ -25,7 +25,7 @@ Follow meta-prompt constraints exactly. Escalate unapproved decisions via `conta
 ## delegate
 output: review-coderabbit.md
 
-Detect the repo default branch: run `git symbolic-ref refs/remotes/origin/HEAD | sed 's|.*/||'`. Then run `cr review --plain --base <detected-branch> > {chain_dir}/review-coderabbit.md 2>&1`. If cr is not found or exits non-zero, write `WARNING: CodeRabbit review skipped — cr not available or failed.` to `{chain_dir}/review-coderabbit.md` and exit 0.
+Detect the repo default branch: run `git symbolic-ref refs/remotes/origin/HEAD | sed 's|.*/||'`. Then run `coderabbit review --plain --base <detected-branch> > {chain_dir}/review-coderabbit.md 2>&1`. If coderabbit is not found or exits non-zero, write `WARNING: CodeRabbit review skipped — coderabbit not available or failed.` to `{chain_dir}/review-coderabbit.md` and exit 0.
 
 ## parallel
 concurrency: 3

--- a/templates/pi/prompts/implement.md
+++ b/templates/pi/prompts/implement.md
@@ -78,7 +78,7 @@ Output: `progress.md` in `chainDir`.
 ```json
 {
   "agent": "delegate",
-  "task": "Detect the repo default branch: run `git symbolic-ref refs/remotes/origin/HEAD | sed 's|.*/||'`. Then run `cr review --plain --base <detected-branch> > <chainDir>/review-coderabbit.md 2>&1`. If cr is not found or exits non-zero, write `WARNING: CodeRabbit review skipped — cr not available or failed.` to `<chainDir>/review-coderabbit.md` and exit 0.",
+  "task": "Detect the repo default branch: run `git symbolic-ref refs/remotes/origin/HEAD | sed 's|.*/||'`. Then run `coderabbit review --plain --base <detected-branch> > <chainDir>/review-coderabbit.md 2>&1`. If coderabbit is not found or exits non-zero, write `WARNING: CodeRabbit review skipped — coderabbit not available or failed.` to `<chainDir>/review-coderabbit.md` and exit 0.",
   "chainDir": "<chainDir from Step 0>"
 }
 ```

--- a/templates/pi/skills/coderabbit/SKILL.md
+++ b/templates/pi/skills/coderabbit/SKILL.md
@@ -1,31 +1,31 @@
 ---
 name: coderabbit
-description: Run a CodeRabbit CLI (`cr`) code review. Use this skill only when the user explicitly says "Use CR", "Ask CodeRabbit", or during /implement (Step 3.5). Do not trigger on general review phrases.
+description: Run a CodeRabbit CLI (`coderabbit`) code review. Use this skill only when the user explicitly says "Use CodeRabbit", "Ask CodeRabbit", or during /implement (Step 3.5). Do not trigger on general review phrases.
 ---
 
 # CodeRabbit CLI
 
-The CodeRabbit CLI binary is `cr` (`coderabbit` is an alias — both work identically).
+The CodeRabbit CLI binary is `coderabbit`.
 
 ## Review commands
 
 ```bash
 # Review all local changes vs base branch (default: main)
-cr
+coderabbit
 
 # Review only uncommitted changes (staged + unstaged)
-cr review uncommitted
+coderabbit review uncommitted
 
 # Review only committed changes (branch commits vs base)
-cr review committed
+coderabbit review committed
 
 # Specify a non-default base branch
-cr review --base master
-cr review --base develop
+coderabbit review --base master
+coderabbit review --base develop
 
 # Combine scope and base branch
-cr review uncommitted --base master
-cr review committed --base develop
+coderabbit review uncommitted --base master
+coderabbit review committed --base develop
 ```
 
 ## Workflow
@@ -38,28 +38,28 @@ git status
 git diff origin/main...HEAD --stat
 
 # 2. Run the review
-cr                   # all changes vs main
-cr --base master     # if default branch is master, not main
+coderabbit                   # all changes vs main
+coderabbit --base master     # if default branch is master, not main
 ```
 
 ### Review only staged changes
 
 ```bash
 git add <files>
-cr review uncommitted
+coderabbit review uncommitted
 ```
 
 ### Review committed work on the branch
 
 ```bash
-cr review committed --base main
+coderabbit review committed --base main
 ```
 
 ## Output modes
 
 ```bash
-cr review --plain --base main   # readable text output (default for human/LLM consumption)
-cr review --agent --base main   # structured JSON output (for machine parsing)
+coderabbit review --plain --base main   # readable text output (default for human/LLM consumption)
+coderabbit review --agent --base main   # structured JSON output (for machine parsing)
 ```
 
 Prefer `--plain` when the output will be read by a person or an LLM. Use `--agent` only when a script needs to parse status or findings count.
@@ -69,4 +69,4 @@ Prefer `--plain` when the output will be read by a person or an LLM. Use `--agen
 - Must run from inside a Git repository (`--dir` flag overrides the directory)
 - Reviews stream results to the terminal as they complete
 - Review duration: 7–30+ minutes depending on scope
-- `cr` and `coderabbit` are interchangeable — prefer `cr` for brevity
+- Must use the full `coderabbit` binary name (`cr` alias is not always available)


### PR DESCRIPTION


   ## Why

   The `cr` shorthand alias is not guaranteed to exist — Homebrew cask installs only the
   `coderabbit` binary. Any environment where `cr` is absent silently skips the CodeRabbit
   review step or errors with `command not found`.

   ## Approach

   Find-and-replace every `cr` command reference with `coderabbit` across the four affected
   files. No behavioural or structural changes — purely a naming fix.

   ## How it works

   Updated files:
   - `templates/pi/skills/coderabbit/SKILL.md` — all example commands + description + tips
   - `templates/pi/AGENTS.md` — CodeRabbit policy section, including trigger phrase `"Use CR"` → `"Use CodeRabbit"`
   - `templates/pi/chains/implement.chain.md` — delegate step command
   - `templates/pi/prompts/implement.md` — delegate JSON task block