### PR TITLE
Remove zsh kubeconfig directory hook

### DIFF
--- a/templates/zshrc.sh
+++ b/templates/zshrc.sh
@@ -105,14 +105,6 @@ if command -v starship >/dev/null 2>&1; then
   eval "$(starship init zsh)"
 fi
 
-chpwd() {
-  # Set KUBECONFIG when a local kubeconfig file exists in the CWD.
-  if [ -f "$PWD/kubeconfig" ]
-  then
-    export KUBECONFIG="$PWD/kubeconfig"
-    echo "kubeconfig is ${KUBECONFIG}"
-  fi
-}
 
 # mise version manager/env vars handler/tasks runner
 eval "$(mise activate zsh)"


### PR DESCRIPTION
## Why

The zsh config currently changes `KUBECONFIG` whenever the shell changes into a directory containing `kubeconfig`. Removing that hook prevents implicit environment changes while navigating directories.

## Approach

Remove the custom `chpwd` function from the zsh template and leave the rest of the shell initialization unchanged.

## How it works

`templates/zshrc.sh` no longer defines `chpwd`, so zsh will not run repo-provided logic after directory changes.

## Links

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic KUBECONFIG configuration from local kubeconfig files during shell initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->