### PR TITLE
Add Gemini models to work site and switch oracle/reviewer to Gemini 3.1 Pro

### DIFF
--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -31,7 +31,7 @@ pi_agent_subagent_overrides:
       linear-researcher:
         thinking: "low"
       oracle:
-        model: "anthropic/claude-opus-4-8"
+        model: "google/gemini-3.1-pro-preview"
         thinking: "high"
         # 10-minute ceiling for long reasoning passes over large context.
         # Note: does not extend any API-level streaming limit — only caps
@@ -55,7 +55,7 @@ pi_agent_subagent_overrides:
       researcher:
         thinking: "medium"
       reviewer:
-        model: "anthropic/claude-opus-4-8"
+        model: "google/gemini-3.1-pro-preview"
         thinking: "high"
       scout:
         model: "anthropic/claude-sonnet-4-6"
@@ -93,6 +93,19 @@ pi_agent_mcp_servers:
     # protected-resource metadata, so no static secret is stored.
     # Run `/mcp-auth n8n` in Pi to complete the browser auth flow.
     auth: "oauth"
+
+pi_agent_settings_overrides: |-
+  {
+    "collapseChangelog": true,
+    "enableInstallTelemetry": false,
+    "enabledModels": [
+      "anthropic/claude-sonnet-4-6",
+      "anthropic/claude-haiku-4-5",
+      "anthropic/claude-opus-4-8",
+      "google/gemini-3.1-pro-preview",
+      "google/gemini-3.5-flash"
+    ]
+  }
 
 # Work-specific packages, appended to the global pi_agent_settings_packages list
 pi_agent_settings_extra_packages:


### PR DESCRIPTION
## Why

The work environment had no model whitelist, defaulting to the global list which lacks Gemini models. Oracle and reviewer subagents were hardcoded to Claude Opus, which is slower and more expensive for structural review tasks where Gemini excels.

## Approach

- Add a `pi_agent_settings_overrides` block with an explicit `enabledModels` list that includes both Gemini models alongside the existing Claude models. This gives the work site model selection flexibility without altering the global config.
- Switch oracle and reviewer subagents to `google/gemini-3.1-pro-preview`, which offers strong reasoning for review/oracle use cases at lower cost and latency than Claude Opus.
- Keep all other subagent model assignments unchanged (e.g., scout remains on Claude Sonnet).

## How it works

- `pi_agent_settings_overrides` is a JSON string injected into Pi's site-specific settings, overriding the global `enabledModels` array. The work machine now sees: Claude Sonnet 4.6, Claude Haiku 4.5, Claude Opus 4.8, Gemini 3.1 Pro, and Gemini 3.5 Flash.
- The oracle and reviewer model overrides in `pi_agent_subagent_overrides` were updated from `anthropic/claude-opus-4-8` to `google/gemini-3.1-pro-preview`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated oracle and reviewer agent models to use Google Gemini 3.1 Pro Preview instead of Claude Opus
  * Added new agent settings to control changelog display, disable telemetry collection, and establish an allowlist of enabled AI models including Anthropic Claude and Google Gemini variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->