### PR TITLE
Set scoped models for home Pi agent

### DIFF
--- a/host_vars/home/vars.yml
+++ b/host_vars/home/vars.yml
@@ -41,6 +41,29 @@ pi_agent_subagent_overrides:
         model: "openai-codex/gpt-5.5"
         thinking: "medium"
 
+pi_agent_settings_overrides: |-
+  {
+    "collapseChangelog": true,
+    "enableInstallTelemetry": false,
+    "enabledModels": [
+      "openai-codex/gpt-5.5",
+      "opencode-go/glm-5",
+      "opencode-go/glm-5.1",
+      "opencode-go/kimi-k2.5",
+      "opencode-go/kimi-k2.6",
+      "opencode-go/mimo-v2.5",
+      "opencode-go/mimo-v2.5-pro",
+      "opencode-go/minimax-m2.5",
+      "opencode-go/minimax-m2.7",
+      "opencode-go/minimax-m3",
+      "opencode-go/qwen3.6-plus",
+      "opencode-go/qwen3.7-plus",
+      "opencode-go/qwen3.7-max",
+      "opencode-go/deepseek-v4-pro",
+      "opencode-go/deepseek-v4-flash"
+    ]
+  }
+
 pi_plannotator_planning_model:
   provider: "openai-codex"
   id: "gpt-5.5"


### PR DESCRIPTION
   ## Why

   The home machine's Pi agent had no `enabledModels` setting, so the model picker
   showed every built-in model. Scoping it to a specific list keeps the picker clean
   and ensures only the intended providers — OpenAI Codex and OpenCode — are available
   for interactive use and subagent dispatch.

   ## Approach

   Added `pi_agent_settings_overrides` to `host_vars/home/vars.yml` following the same
   pattern already used on the work site. The OpenCode models are all served by the
   built-in `opencode-go` provider (`opencode.ai/zen/go/v1`), so no custom `models.json`
   entry is needed.

   ## How it works

   The Ansible `pi_agent/tasks/settings.yml` task deep-merges `pi_agent_settings_overrides`
   into `~/.pi/agent/settings.json` on the home host. The new `enabledModels` array restricts
   the picker to:

   - `openai-codex/gpt-5.5`
   - `opencode-go/glm-5`, `glm-5.1`
   - `opencode-go/kimi-k2.5`, `kimi-k2.6`
   - `opencode-go/mimo-v2.5`, `mimo-v2.5-pro`
   - `opencode-go/minimax-m2.5`, `minimax-m2.7`, `minimax-m3`
   - `opencode-go/qwen3.6-plus`, `qwen3.7-plus`, `qwen3.7-max`
   - `opencode-go/deepseek-v4-pro`, `deepseek-v4-flash`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Changelog collapsing feature is now enabled, allowing users to expand and collapse changelog entries for better readability and streamlined navigation of release information

* **Chores**
  * Install telemetry collection has been disabled to protect user privacy
  * AI model availability has been configured with refined and curated model selections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->