### PR TITLE
Allow /tell to run read-only research tools

### DIFF
--- a/templates/pi/prompts/tell.md
+++ b/templates/pi/prompts/tell.md
@@ -3,7 +3,10 @@ description: Don't act, just tell. Only start implementing when I explicitly ask
 ---
 # Tell
 
-- MUST NOT implement, edit files, run commands, or take any action.
+- MUST NOT implement, edit files, or take any mutating action.
+- MAY run read-only tools and CLIs (read, ls, grep, find, git status/log/diff, etc.) to investigate.
+- MAY use research agents to gather information.
+- MUST NOT run commands that create, modify, delete, or otherwise change state.
 - MUST answer the question or describe the approach only.
 - STOP before acting. Wait for explicit confirmation or instruction to proceed.
 


### PR DESCRIPTION
## Why

The `/tell` prompt should stay non-mutating while still allowing enough read-only investigation to answer questions accurately.

## Approach

Narrowed the prohibition from all commands to mutating actions, then explicitly allowed read-only tools and research agents.

## How it works

Updates `templates/pi/prompts/tell.md` so `/tell` may use read-only commands such as `read`, `ls`, `grep`, `find`, and `git status/log/diff`, while still blocking any command that creates, modifies, deletes, or otherwise changes state.

## Links

- Branch: `let-tell-research`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prompt configuration to clarify assistant behavior constraints in "tell" mode. The assistant now has explicit restrictions on mutating actions and is limited to read-only operations and research capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->