### PR TITLE
Fix linear-researcher agent hang in parallel /plan runs

### DIFF
--- a/templates/pi/agents/linear-researcher.agent.md
+++ b/templates/pi/agents/linear-researcher.agent.md
@@ -1,11 +1,9 @@
 ---
 name: linear-researcher
 description: Gathers Linear project context via MCP tools — tickets, milestones, project state, and blockers
-# Linear MCP tools must be declared explicitly here — pi passes --tools to the child
-# process and only listed tools are available. Without them the agent's system prompt
-# instructs it to call linear_issue/project/milestone/team but those calls silently
-# fail, producing a placeholder output instead of real Linear data.
-tools: write, intercom, linear_issue, linear_project, linear_milestone, linear_team
+# mcp is the gateway for all MCP server tools including Linear.
+# intercom removed — the agent must not coordinate with the supervisor during parallel research.
+tools: write, mcp
 thinking: low
 systemPromptMode: replace
 inheritProjectContext: false
@@ -20,7 +18,13 @@ Given a task or topic, query Linear using the available MCP tools and produce a 
 
 Working rules:
 
-- Use `linear_issue`, `linear_project`, `linear_milestone`, and `linear_team` tools.
+- If any tool call fails or Linear is unreachable for any reason,
+  immediately write the output file with a brief note explaining what failed,
+  and exit successfully. Do NOT use intercom. Do NOT ask the supervisor.
+- Use the `mcp` gateway to call Linear tools:
+  - `mcp({ tool: "linear_searchIssues", args: '{"query": "..."}' })`
+  - `mcp({ tool: "linear_getIssue", args: '{"id": "..."}' })`
+  - Discover all available Linear tool names first via `mcp({ server: "linear" })`.
 - When a tool response may be large, pipe it through `ctx_execute` to filter and summarise —
   never paste raw list output into your response.
 - Search for issues related to the task by title, label, or description.
@@ -37,7 +41,7 @@ Queries to consider (adapt to the task):
 Filtering pattern for large issue lists:
 
 ```javascript
-// After calling linear_issue({ action: "list", ... }), process with:
+// After calling mcp({ tool: "linear_searchIssues", args: '{"query": "..."}' }), process with:
 ctx_execute({
   language: "javascript",
   code: `
@@ -75,6 +79,4 @@ Overall project health if available.
 
 What could not be queried or found.
 
-## Supervisor coordination
 
-If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries. Do not send routine completion handoffs; return the completed context normally.


### PR DESCRIPTION


   ## Why

   `linear-researcher` hangs every time `/plan` runs it in a parallel batch, blocking
   the whole plan until the session times out. Three root causes all lived in the same
   agent definition file:

   1. The agent called `intercom({ action: "ask" })` to probe for Linear MCP access.
      `ask` is blocking — in a detached parallel run the parent never polls for incoming
      asks, so the child waits forever.
   2. The `tools:` field listed `linear_issue`, `linear_project`, `linear_milestone`,
      `linear_team` — none of these exist as first-class pi tools. All Linear tools must
      go through the `mcp` gateway. Without `mcp` in the list the agent silently could
      not call any of them.
   3. When the agent could not determine tool availability it fell back to the intercom
      ask instead of writing the output file and exiting cleanly.

   ## Approach

   Remove all supervisor coordination from the agent entirely — it is architecturally
   incompatible with parallel execution. The agent now owns its own failure path: write
   the output file with a note and exit. No blocking calls, no escalation.

   Replace direct `linear_*` tool references with `mcp({ tool: "linear_...", args })` so
   the agent can actually reach the Linear MCP server.

   ## How it works

   - `tools:` reduced to `write, mcp` — `mcp` is the gateway for all Linear tools;
     `intercom` removed.
   - Graceful exit rule added at the top of the working rules: on any failure, write
     `linear-context.md` with a brief error note and exit successfully.
   - All tool call examples updated to use the `mcp` gateway pattern.
   - `Supervisor coordination` section removed — `contact_supervisor` is an alias for
     `intercom ask` and must not be called from a parallel child.