### PR TITLE
Drop pi-intercom and move oracle/reviewer to Opus 4.8

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -187,7 +187,6 @@ pi_agent_settings_packages:
   - "git:github.com/boga/pi-local-claude-loader"
   - "npm:@plannotator/pi-extension"
   - "npm:context-mode"
-  - "npm:pi-intercom"
   - "npm:pi-mcp-adapter"
   - "npm:pi-mono-ask-user-question"
   - "npm:pi-subagents"

--- a/host_vars/home/vars.yml
+++ b/host_vars/home/vars.yml
@@ -23,8 +23,8 @@ pi_agent_subagent_overrides:
         model: "openai-codex/gpt-5.5"
         thinking: "low"
       oracle:
-        model: "anthropic/claude-opus-4-8"
-        thinking: "high"
+        model: "openai-codex/gpt-5.5"
+        thinking: "xhigh"
       planner:
         model: "openai-codex/gpt-5.5"
         thinking: "xhigh"
@@ -32,8 +32,8 @@ pi_agent_subagent_overrides:
         model: "openai-codex/gpt-5.5"
         thinking: "medium"
       reviewer:
-        model: "anthropic/claude-opus-4-8"
-        thinking: "high"
+        model: "openai-codex/gpt-5.5"
+        thinking: "xhigh"
       scout:
         model: "openai-codex/gpt-5.5"
         thinking: "medium"
@@ -46,7 +46,6 @@ pi_agent_settings_overrides: |-
     "collapseChangelog": true,
     "enableInstallTelemetry": false,
     "enabledModels": [
-      "anthropic/claude-opus-4-8",
       "openai-codex/gpt-5.5",
       "opencode-go/glm-5",
       "opencode-go/glm-5.1",

--- a/host_vars/home/vars.yml
+++ b/host_vars/home/vars.yml
@@ -23,8 +23,8 @@ pi_agent_subagent_overrides:
         model: "openai-codex/gpt-5.5"
         thinking: "low"
       oracle:
-        model: "openai-codex/gpt-5.5"
-        thinking: "xhigh"
+        model: "anthropic/claude-opus-4-8"
+        thinking: "high"
       planner:
         model: "openai-codex/gpt-5.5"
         thinking: "xhigh"
@@ -32,8 +32,8 @@ pi_agent_subagent_overrides:
         model: "openai-codex/gpt-5.5"
         thinking: "medium"
       reviewer:
-        model: "openai-codex/gpt-5.5"
-        thinking: "xhigh"
+        model: "anthropic/claude-opus-4-8"
+        thinking: "high"
       scout:
         model: "openai-codex/gpt-5.5"
         thinking: "medium"
@@ -46,6 +46,7 @@ pi_agent_settings_overrides: |-
     "collapseChangelog": true,
     "enableInstallTelemetry": false,
     "enabledModels": [
+      "anthropic/claude-opus-4-8",
       "openai-codex/gpt-5.5",
       "opencode-go/glm-5",
       "opencode-go/glm-5.1",

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -31,7 +31,7 @@ pi_agent_subagent_overrides:
       linear-researcher:
         thinking: "low"
       oracle:
-        model: "google/gemini-3.1-pro-preview"
+        model: "anthropic/claude-opus-4-8"
         thinking: "high"
         # 10-minute ceiling for long reasoning passes over large context.
         # Note: does not extend any API-level streaming limit — only caps
@@ -55,7 +55,7 @@ pi_agent_subagent_overrides:
       researcher:
         thinking: "medium"
       reviewer:
-        model: "google/gemini-3.1-pro-preview"
+        model: "anthropic/claude-opus-4-8"
         thinking: "high"
       scout:
         model: "anthropic/claude-sonnet-4-6"


### PR DESCRIPTION


   ## Why

   Subagents hung indefinitely whenever one called `contact_supervisor` during a
   chain or parallel run. That tool is a blocking intercom ask: the child freezes
   waiting for a reply the parent can never send (the parent is itself blocked
   inside the `subagent()` call, or the ask lands in an exited coordinator
   session). There is no timeout, so the hang is permanent.

   Rather than restrict each agent's toolset, this removes the source: dropping
   the `pi-intercom` extension removes the `contact_supervisor`/`intercom` tools
   entirely, so no agent can issue a blocking ask.

   Separately, `oracle` and `reviewer` are promoted to a stronger reasoning model.

   ## What

   - **Drop `npm:pi-intercom`** from `pi_agent_settings_packages` (`group_vars/all.yml`).
     Removes `contact_supervisor` globally — fixes the hang at the root.
   - **`oracle` + `reviewer` → `anthropic/claude-opus-4-8`, thinking `high`**
     on both hosts:
     - `work`: was `google/gemini-3.1-pro-preview`.
     - `home`: was `openai-codex/gpt-5.5`; also added `anthropic/claude-opus-4-8`
       to `enabledModels` so the override resolves there.

   ## Notes

   - User-scoped config; no project files affected.
   - Takes effect after applying the playbook
     (`ansible-playbook site.yml --limit <host> --tags configs`). The settings
     merge is recursive/additive — re-running drops `pi-intercom` from the
     generated `settings.json` packages list.
   - The plan's optional `tools:` allowlists were intentionally skipped; dropping
     the extension makes them redundant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated package dependency to streamline configuration
  * Updated underlying AI models powering core agents for enhanced performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->