### PR TITLE
Update Zed settings template with agent servers and UI preferences

### DIFF
--- a/templates/zed/settings.json
+++ b/templates/zed/settings.json
@@ -1,6 +1,29 @@
 // {{ ansible_managed }}
 
 {
+  "prettier": {
+    "allowed": true
+  },
+  "autosave": {
+    "after_delay": {
+      "milliseconds": 1000
+    }
+  },
+  "icon_theme": {
+    "mode": "system",
+    "light": "JetBrains New UI Icons (Light)",
+    "dark": "JetBrains New UI Icons (Dark)"
+  },
+  "default_open_behavior": "new_window",
+  "cli_default_open_behavior": "new_window",
+  "agent_servers": {
+    "pi-acp": {
+      "type": "registry"
+    },
+    "claude-acp": {
+      "type": "registry"
+    }
+  },
   "theme": {
     "mode": "system",
     "dark": "Fleet Dark",
@@ -18,8 +41,8 @@
   },
   "base_keymap": "JetBrains",
   "enable_language_server": true,
-  "buffer_font_size": 15,
-  "buffer_font_family": "Fira Code",
+  "buffer_font_size": 15.0,
+  "buffer_font_family": "Iosevka Fixed",
   "format_on_save": "off",
   "collaboration_panel": {
     "button": false,

--- a/templates/zed/settings.json
+++ b/templates/zed/settings.json
@@ -1,6 +1,11 @@
 // {{ ansible_managed }}
 
 {
+  "agent_buffer_font_size": 15.0,
+  "agent_ui_font_size": 16.0,
+  "edit_predictions": {
+    "allow_data_collection": "no"
+  },
   "prettier": {
     "allowed": true
   },


### PR DESCRIPTION
## Why

The Zed settings template was out of sync with the current host config and missing several new
settings introduced in recent Zed versions: ACP agent servers, agent panel font sizing, edit
predictions opt-out, icon theme, and autosave.

## Approach

Synced the template from the live host config rather than reconstructing manually, to ensure the
deployed file matches what's actually in use. ACP agent servers use `"type": "registry"` so Zed
resolves the agent binary from its own registry — no hardcoded paths needed.

## How it works

- Adds `agent_servers` with `pi-acp` and `claude-acp` as registry-type entries, enabling Pi and
  Claude as External Agents in the Zed Agent Panel
- Adds `agent_buffer_font_size`, `agent_ui_font_size` for the agent panel
- Opts out of edit prediction data collection
- Switches `buffer_font_family` from Fira Code to Iosevka Fixed
- Adds `autosave`, `icon_theme`, `default_open_behavior`, and `prettier` settings