### PR TITLE
Remove stale configs tag example and add no-autorun policy to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,6 @@ ansible-playbook site.yml --limit home
 ansible-playbook site.yml --limit work
 ```
 
-### Running Specific Tasks
+## Policy
 
-Use `--tags` to run only a subset of tasks:
-
-- `configs`: Copies configuration files and generates shell integrations.
-
-```bash
-ansible-playbook site.yml --limit home --tags configs
-```
+**Never run `ansible-playbook` automatically.** The user always runs it manually. Only prepare or edit files — do not execute playbooks.


### PR DESCRIPTION
## Why

`CLAUDE.md` contained a `--tags configs` example that referenced a tag not defined anywhere
in the playbooks, and gave no guidance about whether the agent should run `ansible-playbook`
itself. This caused confusion and left the door open for unintended playbook executions.

## Approach

Removed the misleading tag example entirely rather than fixing it, since no real tags are
currently defined. Added an explicit policy section instead of a comment in the body so agents
treat it as a hard constraint.

## How it works

- Drops the `### Running Specific Tasks` section and its `--tags configs` example.
- Replaces it with a `## Policy` note: the user always runs `ansible-playbook` manually —
  the agent must never execute it automatically.