### PR TITLE
Trim enabled models and switch work host to claude-sonnet-5

### DIFF
--- a/host_vars/home/vars.yml
+++ b/host_vars/home/vars.yml
@@ -46,21 +46,7 @@ pi_agent_settings_overrides: |-
     "collapseChangelog": true,
     "enableInstallTelemetry": false,
     "enabledModels": [
-      "openai-codex/gpt-5.5",
-      "opencode-go/glm-5",
-      "opencode-go/glm-5.1",
-      "opencode-go/kimi-k2.5",
-      "opencode-go/kimi-k2.6",
-      "opencode-go/mimo-v2.5",
-      "opencode-go/mimo-v2.5-pro",
-      "opencode-go/minimax-m2.5",
-      "opencode-go/minimax-m2.7",
-      "opencode-go/minimax-m3",
-      "opencode-go/qwen3.6-plus",
-      "opencode-go/qwen3.7-plus",
-      "opencode-go/qwen3.7-max",
-      "opencode-go/deepseek-v4-pro",
-      "opencode-go/deepseek-v4-flash"
+      "openai-codex/gpt-5.5"
     ]
   }
 

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -10,7 +10,7 @@ pi_plannotator_planning_model:
 pi_plannotator_planning_thinking: "xhigh"
 pi_plannotator_executing_model:
   provider: "anthropic"
-  id: "claude-sonnet-4-6"
+  id: "claude-sonnet-5"
 pi_plannotator_executing_thinking: "medium"
 pi_plannotator_reviewing_model:
   provider: "anthropic"
@@ -58,10 +58,10 @@ pi_agent_subagent_overrides:
         model: "anthropic/claude-opus-4-8"
         thinking: "high"
       scout:
-        model: "anthropic/claude-sonnet-4-6"
+        model: "anthropic/claude-sonnet-5"
         thinking: "low"
       worker:
-        model: "anthropic/claude-sonnet-4-6"
+        model: "anthropic/claude-sonnet-5"
         thinking: "medium"
         # worker ships defaultContext: fork (continue-the-thread intent).
         # In the implement chain (context-builder→worker→reviewer×3) this
@@ -107,11 +107,9 @@ pi_agent_settings_overrides: |-
     "collapseChangelog": true,
     "enableInstallTelemetry": false,
     "enabledModels": [
-      "anthropic/claude-sonnet-4-6",
+      "anthropic/claude-sonnet-5",
       "anthropic/claude-haiku-4-5",
-      "anthropic/claude-opus-4-8",
-      "google/gemini-3.1-pro-preview",
-      "google/gemini-3.5-flash"
+      "anthropic/claude-opus-4-8"
     ]
   }
 


### PR DESCRIPTION
## Why

   Model lineups drift over time — home had a long list of opencode-go
   variants no longer in use, and work was still pinned to
   claude-sonnet-4-6 in three places while claude-sonnet-5 is now the
   model of choice.

   ## Approach

   Kept the change scoped to host_vars so it's per-machine: home only
   needed enabledModels trimmed, work needed both enabledModels updated
   and every claude-sonnet-4-6 reference (pi_plannotator_executing_model,
   scout, worker) bumped in lockstep to avoid pointing subagents at a
   model no longer in enabledModels.

   ## How it works

   - host_vars/home/vars.yml: enabledModels trimmed to openai-codex/gpt-5.5,
     dropping unused opencode-go/* entries.
   - host_vars/work/vars.yml: enabledModels swaps claude-sonnet-4-6 for
     claude-sonnet-5 and drops gemini-3.1-pro-preview/gemini-3.5-flash;
     pi_plannotator_executing_model, scout, and worker model refs updated
     to claude-sonnet-5 to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the available AI model options across environments.
  * Default model selections now favor newer Claude and Codex variants.

* **Bug Fixes**
  * Removed several older or less relevant models from the enabled list to streamline model choice.
  * Improved consistency between global model availability and subagent defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->