### PR TITLE
Add Herdr Pi integration to pi_agent role

### DIFF
--- a/roles/pi_agent/tasks/herdr_integration.yml
+++ b/roles/pi_agent/tasks/herdr_integration.yml
@@ -1,0 +1,20 @@
+---
+- name: "Check for herdr on PATH"
+  ansible.builtin.command: command -v herdr
+  register: herdr_check
+  changed_when: false
+  failed_when: false
+
+- name: "Ensure Pi agent extensions directory exists"
+  ansible.builtin.file:
+    path: "{{ pi_agent_dir }}/extensions"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_group }}"
+    mode: "0755"
+  when: herdr_check.rc == 0
+
+- name: "Install Herdr Pi integration"
+  ansible.builtin.command: herdr integration install pi
+  changed_when: true
+  when: herdr_check.rc == 0

--- a/roles/pi_agent/tasks/main.yml
+++ b/roles/pi_agent/tasks/main.yml
@@ -12,3 +12,6 @@
 
 - name: "Configure Pi agent MCP servers"
   ansible.builtin.import_tasks: mcp.yml
+
+- name: "Install Herdr Pi integration"
+  ansible.builtin.import_tasks: herdr_integration.yml

--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -55,6 +55,11 @@ color15  #ffffff
 # Copy to clipboard on selection
 copy_on_select yes
 
+# Force native selection on left-drag even when the pane program (e.g. Herdr)
+# has grabbed the mouse. Avoids the round-trip delay through the grabbing
+# program's own mouse handling/redraw loop.
+mouse_map left press grabbed,ungrabbed mouse_selection normal
+
 # Cursor and selection tweaks
 cursor_text_color       background
 cursor_beam_thickness   2.0

--- a/templates/kitty.conf
+++ b/templates/kitty.conf
@@ -55,11 +55,6 @@ color15  #ffffff
 # Copy to clipboard on selection
 copy_on_select yes
 
-# Force native selection on left-drag even when the pane program (e.g. Herdr)
-# has grabbed the mouse. Avoids the round-trip delay through the grabbing
-# program's own mouse handling/redraw loop.
-mouse_map left press grabbed,ungrabbed mouse_selection normal
-
 # Cursor and selection tweaks
 cursor_text_color       background
 cursor_beam_thickness   2.0


### PR DESCRIPTION
## Why

   After installing Herdr, the Pi agent needs its Herdr integration registered so the
   `herdr` skill can communicate with the running instance over the local socket.
   This step was manual and easy to miss on a fresh machine setup.

   ## Approach

   Runs `herdr integration install pi` conditionally — only when `herdr` is present on
   PATH. This keeps the role idempotent on machines that don't use Herdr, and avoids
   a hard dependency on Herdr being installed via Homebrew before the role runs.

   ## How it works

   A new task file `roles/pi_agent/tasks/herdr_integration.yml` is imported at the
   end of `main.yml`. It:
   1. Probes `herdr` on PATH with `command -v` (never fails).
   2. Ensures `~/.pi/agent/extensions/` exists (directory the integration writes into).
   3. Runs `herdr integration install pi` when Herdr is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic setup for the Herdr Pi integration during Pi agent configuration.
  * The installer now checks for the Herdr CLI before attempting installation, and only proceeds when it is available.
  * Created the required extensions directory as part of the setup flow to support the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->