### PR TITLE
Add IntelliJ IDEA MCP server to Pi config

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -215,6 +215,24 @@ pi_agent_mcp_servers:
   context7:
     type: "streamable-http"
     url: "https://mcp.context7.com/mcp"
+  intellij-idea:
+    type: "streamable-http"
+    url: "http://127.0.0.1:64342/stream"
+    # IntelliJ IDEA's built-in MCP server (streamable-http) on localhost. The
+    # IJ_MCP_SERVER_PROJECT_PATH header tells the IDE which open project to
+    # target. Pi's MCP adapter interpolates ${VAR} from the environment at
+    # connection time (there is no literal per-call substitution), so ${PWD}
+    # resolves to the directory Pi was launched in — i.e. the worktree that
+    # IDEA is opened on. Custom headers also disable OAuth auto-detection, so
+    # no `auth` is needed for this local endpoint. If you switch the project
+    # mid-session, run `/mcp reconnect intellij-idea` to re-resolve the header
+    # from the new $PWD.
+    #
+    # NOTE: the `work` host redefines pi_agent_mcp_servers in full (Ansible
+    # hash_behaviour=replace), so keep this entry in sync with the copy in
+    # host_vars/work/vars.yml.
+    headers:
+      IJ_MCP_SERVER_PROJECT_PATH: "${PWD}"
 
 pi_agent_settings_packages:
   - "git:github.com/boga/pi-local-claude-loader"

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -102,9 +102,9 @@ pi_agent_mcp_servers:
     # Run `/mcp-auth n8n` in Pi to complete the browser auth flow.
     auth: "oauth"
   intellij-idea:
-    type: "sse"
-    url: "http://127.0.0.1:64342/sse"
-    # IntelliJ IDEA's built-in MCP server (SSE) on localhost. The
+    type: "streamable-http"
+    url: "http://127.0.0.1:64342/stream"
+    # IntelliJ IDEA's built-in MCP server (streamable-http) on localhost. The
     # IJ_MCP_SERVER_PROJECT_PATH header tells the IDE which open project to
     # target. Pi's MCP adapter interpolates ${VAR} from the environment at
     # connection time (there is no literal per-call substitution), so ${PWD}

--- a/host_vars/work/vars.yml
+++ b/host_vars/work/vars.yml
@@ -101,6 +101,20 @@ pi_agent_mcp_servers:
     # protected-resource metadata, so no static secret is stored.
     # Run `/mcp-auth n8n` in Pi to complete the browser auth flow.
     auth: "oauth"
+  intellij-idea:
+    type: "sse"
+    url: "http://127.0.0.1:64342/sse"
+    # IntelliJ IDEA's built-in MCP server (SSE) on localhost. The
+    # IJ_MCP_SERVER_PROJECT_PATH header tells the IDE which open project to
+    # target. Pi's MCP adapter interpolates ${VAR} from the environment at
+    # connection time (there is no literal per-call substitution), so ${PWD}
+    # resolves to the directory Pi was launched in — i.e. the worktree that
+    # IDEA is opened on. Custom headers also disable OAuth auto-detection, so
+    # no `auth` is needed for this local endpoint. If you switch the project
+    # mid-session, run `/mcp reconnect intellij-idea` to re-resolve the header
+    # from the new $PWD.
+    headers:
+      IJ_MCP_SERVER_PROJECT_PATH: "${PWD}"
 
 pi_agent_settings_overrides: |-
   {


### PR DESCRIPTION
## Why

   Pi needs access to IntelliJ IDEA's built-in MCP server so it can interact with
   whatever project is currently open in the IDE (navigate code, inspect state,
   etc.) alongside the existing MCP servers.

   ## Approach

   The IDE exposes a localhost MCP endpoint, currently on the streamable-http
   transport (switched from an earlier SSE-based endpoint during iteration).
   Configured on both work and home hosts.

   Rather than duplicating the server definition per host — `work` fully
   overrides `pi_agent_mcp_servers` (Ansible `hash_behaviour` defaults to
   `replace`, so host_vars don't merge with group_vars) — the definition lives
   once as `intellij_mcp_server` in `group_vars/all.yml` and is folded into each
   host's resolved `pi_agent_mcp_servers` via `combine()` in
   `roles/pi_agent/tasks/mcp.yml`. This keeps a single source of truth while
   still applying to every host regardless of whether it overrides the base
   server list.

   ## How it works

   - `roles/pi_agent/defaults/main.yml`: adds `intellij_mcp_server: {}` default.
   - `roles/pi_agent/tasks/mcp.yml`: merges `intellij_mcp_server` into
     `pi_agent_mcp_servers` (`combine(..., recursive=true)`) before writing
     `mcp.json`.
   - `group_vars/all.yml`: defines the single `intellij_mcp_server` entry
     (`type: streamable-http`, `url: 127.0.0.1/stream`).
   - `host_vars/work/vars.yml`: removes the now-redundant inline `intellij-idea`
     entry (previously duplicated here).

   The `IJ_MCP_SERVER_PROJECT_PATH` header uses `${PWD}`. Pi's MCP adapter
   interpolates `${VAR}` from the environment at connection time (there's no
   per-call substitution), so it resolves to whatever directory Pi was launched
   from — i.e. the worktree/project IDEA has open. If you switch projects
   mid-session, run `/mcp reconnect intellij-idea` to re-resolve the header.

   ## Links

   - N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IntelliJ IDEA integration through a local MCP server.
  * The integration automatically uses the currently active project directory.
  * Enabled the configuration for both shared environments and the work setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->