### PR TITLE
Add postgres skill for pi agent

### DIFF
--- a/templates/pi/skills/postgres/SKILL.md
+++ b/templates/pi/skills/postgres/SKILL.md
@@ -107,15 +107,19 @@ rows or wide columns, so only the derived answer enters context:
 
 ```javascript
 ctx_execute(language: "shell", code: `
-  psql "$DATABASE_URL" -At -F',' -c "SELECT status, COUNT(*) FROM users GROUP BY status;"
+  psql "$DATABASE_URL" --csv -t -c "SELECT status, COUNT(*) FROM users GROUP BY status;"
 `)
 ```
 
-Use `-At -F','` (unaligned, tuples-only, comma field separator) for machine-parseable
-output. Push filtering/aggregation into the SQL or the sandbox code so only the
-derived answer (counts, aggregates, filtered rows) is printed — do not select raw
-PII columns (email, name, phone, address, etc.) unless the task explicitly
-requires inspecting those values.
+Prefer `--csv -t` (tuples-only, quoting-safe CSV output; requires PostgreSQL 12+
+client) for machine-parseable output, since it properly quotes/escapes fields that
+contain the delimiter, newlines, or quotes. If `--csv` is unavailable (older
+`psql`), fall back to `-At -F','` but be aware it is not quoting-safe — only use it
+for queries where the selected columns cannot contain a comma or newline (e.g.
+status enums, counts, ids), not free-text/PII columns. Push filtering/aggregation
+into the SQL or the sandbox code so only the derived answer (counts, aggregates,
+filtered rows) is printed — do not select raw PII columns (email, name, phone,
+address, etc.) unless the task explicitly requires inspecting those values.
 
 ## Safety
 

--- a/templates/pi/skills/postgres/SKILL.md
+++ b/templates/pi/skills/postgres/SKILL.md
@@ -1,92 +1,96 @@
 ---
 name: postgres
-description: Query and inspect Postgres databases using psql, with DATABASE_URL sourced from the project's mise.toml (or an ancestor directory's mise.toml). Use when the user asks to run SQL, inspect schema/tables, or debug data in a Postgres-backed project.
+description: Query and inspect Postgres databases using psql, with DATABASE_URL read from the environment. Use when the user asks to run SQL, inspect schema/tables, or debug data in a Postgres-backed project.
 ---
 
 # Postgres
 
-Runs `psql` against the `DATABASE_URL` defined in the project's `mise.toml` (or an
-ancestor directory's `mise.toml`, per mise's usual config resolution).
+Runs `psql` against the `DATABASE_URL` already present in the environment.
 
 ## How DATABASE_URL Is Resolved
 
-Do not assume `DATABASE_URL` is already exported in the current shell — the agent's
-bash tool may run a non-interactive shell that never sourced `mise activate`. Never
-read, print, or echo the value of `DATABASE_URL` (it contains credentials) — only
-check that it resolves to a non-empty value, via `mise`, from the project directory
-(`cwd`):
+Do not assume `DATABASE_URL` is set — check first. Never read, print, or echo its
+value (it contains credentials) — only check that it resolves to a non-empty value:
 
 ```bash
-mise exec -- sh -c 'test -n "$DATABASE_URL"' && echo present || echo absent
+test -n "$DATABASE_URL" && echo present || echo absent
 ```
 
-`mise exec -- <command>` loads env vars (including `[env]` entries) from the nearest
-`mise.toml` walking up from `cwd`, then runs `<command>` with that env applied — no
-prior shell activation required.
+This prohibition includes partial or truncated output too — no `head`, `cut`,
+`grep -o`, `awk`, substring slicing, or any command that surfaces even a fragment of
+the value (e.g. `echo $DATABASE_URL | head -c 20`). A leaked prefix can still expose
+scheme, user, or host. The only permitted check is the `test -n` presence check
+above.
 
 ### If DATABASE_URL is absent
 
 Stop. Do not guess, invent, or ask the user to paste a connection string into chat.
 Report this exact failure and instructions:
 
-> `DATABASE_URL` is not set for this project. Provide it one of two ways:
+> `DATABASE_URL` is not set in this shell. Provide it one of two ways:
 >
 > 1. **Per-shell (temporary):** `export DATABASE_URL="postgres://user:password@host:5432/dbname"`
-> 2. **Per-project (persistent, recommended):** add to `mise.toml` in this project
->    (or an ancestor directory):
+> 2. **Per-project (persistent, via mise):** if this project uses `mise`, add to
+>    `mise.toml` (in this project or an ancestor directory):
 >    ```toml
 >    [env]
 >    DATABASE_URL = "postgres://user:password@host:5432/dbname"
 >    ```
->    Then re-run the task — `mise exec` will pick it up automatically.
+>    then make sure `mise` is activated in your shell so the var is exported
+>    automatically. Then re-run the task.
 
 Do not proceed with any `psql`/`pg_dump` command until the existence check passes.
 
-### Expected mise.toml shape
+## Usage
 
-The project (or an ancestor directory) is expected to define something like:
+### Discovery First
 
-```toml
-[env]
-DATABASE_URL = "postgres://user:password@localhost:5432/mydb"
+When the task is to find or confirm data (e.g., "find X users/table", "does a Y
+table exist"), run `\dt` first:
+
+```bash
+psql "$DATABASE_URL" -c "\dt"
 ```
 
-## Usage
+Do this before grepping application source code or guessing table names. Listing
+tables is one cheap command vs. multiple grep/read round-trips through source code.
+Only fall back to source-code search if the `\dt` output doesn't make the right
+table obvious.
 
 ### Run a query
 
 ```bash
-mise exec -- psql "$DATABASE_URL" -c "SELECT * FROM users LIMIT 10;"
+psql "$DATABASE_URL" -c "SELECT * FROM users LIMIT 10;"
 ```
 
 ### List tables
 
 ```bash
-mise exec -- psql "$DATABASE_URL" -c "\dt"
+psql "$DATABASE_URL" -c "\dt"
 ```
 
 ### Describe a table
 
 ```bash
-mise exec -- psql "$DATABASE_URL" -c "\d+ users"
+psql "$DATABASE_URL" -c "\d+ users"
 ```
 
 ### List schemas
 
 ```bash
-mise exec -- psql "$DATABASE_URL" -c "\dn"
+psql "$DATABASE_URL" -c "\dn"
 ```
 
 ### Run a .sql file
 
 ```bash
-mise exec -- psql "$DATABASE_URL" -f path/to/query.sql
+psql "$DATABASE_URL" -f path/to/query.sql
 ```
 
 ### Dump schema only (no data)
 
 ```bash
-mise exec -- pg_dump --schema-only "$DATABASE_URL"
+pg_dump --schema-only "$DATABASE_URL"
 ```
 
 ## Output Handling
@@ -97,7 +101,7 @@ rows or wide columns, so only the derived answer enters context:
 
 ```javascript
 ctx_execute(language: "shell", code: `
-  mise exec -- psql "$DATABASE_URL" -At -F',' -c "SELECT id, email FROM users LIMIT 1000;"
+  psql "$DATABASE_URL" -At -F',' -c "SELECT id, email FROM users LIMIT 1000;"
 `)
 ```
 

--- a/templates/pi/skills/postgres/SKILL.md
+++ b/templates/pi/skills/postgres/SKILL.md
@@ -13,7 +13,7 @@ Do not assume `DATABASE_URL` is set — check first. Never read, print, or echo 
 value (it contains credentials) — only check that it resolves to a non-empty value:
 
 ```bash
-test -n "$DATABASE_URL" && echo present || echo absent
+test -n "${DATABASE_URL:-}" && echo present || echo absent
 ```
 
 This prohibition includes partial or truncated output too — no `head`, `cut`,
@@ -46,16 +46,17 @@ Do not proceed with any `psql`/`pg_dump` command until the existence check passe
 ### Discovery First
 
 When the task is to find or confirm data (e.g., "find X users/table", "does a Y
-table exist"), run `\dt` first:
+table exist"), run a schema-aware `\dt` first:
 
 ```bash
-psql "$DATABASE_URL" -c "\dt"
+psql "$DATABASE_URL" -c "\dt public.*"
 ```
 
-Do this before grepping application source code or guessing table names. Listing
-tables is one cheap command vs. multiple grep/read round-trips through source code.
-Only fall back to source-code search if the `\dt` output doesn't make the right
-table obvious.
+Use `\dt schema_name.*` if the project uses a non-`public` schema. Do this before
+grepping application source code or guessing table names. Listing tables is one
+cheap command vs. multiple grep/read round-trips through source code. Only fall
+back to source-code search if the `\dt` output doesn't make the right table
+obvious.
 
 ### Run a query
 
@@ -84,8 +85,13 @@ psql "$DATABASE_URL" -c "\dn"
 ### Run a .sql file
 
 ```bash
-psql "$DATABASE_URL" -f path/to/query.sql
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f path/to/query.sql
 ```
+
+`ON_ERROR_STOP=1` halts execution at the first SQL error instead of continuing
+with later statements. For write scripts, wrap the script's statements in an
+explicit `BEGIN; ... COMMIT;` transaction so a failure can be rolled back instead
+of leaving partial changes applied.
 
 ### Dump schema only (no data)
 
@@ -101,18 +107,23 @@ rows or wide columns, so only the derived answer enters context:
 
 ```javascript
 ctx_execute(language: "shell", code: `
-  psql "$DATABASE_URL" -At -F',' -c "SELECT id, email FROM users LIMIT 1000;"
+  psql "$DATABASE_URL" -At -F',' -c "SELECT status, COUNT(*) FROM users GROUP BY status;"
 `)
 ```
 
 Use `-At -F','` (unaligned, tuples-only, comma field separator) for machine-parseable
-output when you intend to filter/aggregate in code rather than eyeball it.
+output. Push filtering/aggregation into the SQL or the sandbox code so only the
+derived answer (counts, aggregates, filtered rows) is printed — do not select raw
+PII columns (email, name, phone, address, etc.) unless the task explicitly
+requires inspecting those values.
 
 ## Safety
 
-- Treat any `INSERT`/`UPDATE`/`DELETE`/`DROP`/`TRUNCATE`/`ALTER` statement as a write —
-  confirm with the user before running it, unless they explicitly asked for that exact
-  change.
+- Require explicit user confirmation before running any command or script that can
+  change database state or privileges — this is not limited to a fixed keyword
+  list. It includes (non-exhaustively) `INSERT`/`UPDATE`/`DELETE`/`DROP`/
+  `TRUNCATE`/`ALTER`/`CREATE`/`CREATE OR REPLACE`/`GRANT`/`REVOKE`/`MERGE`/`CALL`/
+  `DO`/`\copy`, unless the user explicitly asked for that exact change.
 - Default to read-only exploration (`SELECT`, `\d`, `\dt`, `EXPLAIN`) when the task is
   "inspect" or "debug", not "modify."
 - Never read, print, or log the value of `$DATABASE_URL` (it contains credentials).

--- a/templates/pi/skills/postgres/SKILL.md
+++ b/templates/pi/skills/postgres/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: postgres
+description: Query and inspect Postgres databases using psql, with DATABASE_URL sourced from the project's mise.toml (or an ancestor directory's mise.toml). Use when the user asks to run SQL, inspect schema/tables, or debug data in a Postgres-backed project.
+---
+
+# Postgres
+
+Runs `psql` against the `DATABASE_URL` defined in the project's `mise.toml` (or an
+ancestor directory's `mise.toml`, per mise's usual config resolution).
+
+## How DATABASE_URL Is Resolved
+
+Do not assume `DATABASE_URL` is already exported in the current shell — the agent's
+bash tool may run a non-interactive shell that never sourced `mise activate`. Never
+read, print, or echo the value of `DATABASE_URL` (it contains credentials) — only
+check that it resolves to a non-empty value, via `mise`, from the project directory
+(`cwd`):
+
+```bash
+mise exec -- sh -c 'test -n "$DATABASE_URL"' && echo present || echo absent
+```
+
+`mise exec -- <command>` loads env vars (including `[env]` entries) from the nearest
+`mise.toml` walking up from `cwd`, then runs `<command>` with that env applied — no
+prior shell activation required.
+
+### If DATABASE_URL is absent
+
+Stop. Do not guess, invent, or ask the user to paste a connection string into chat.
+Report this exact failure and instructions:
+
+> `DATABASE_URL` is not set for this project. Provide it one of two ways:
+>
+> 1. **Per-shell (temporary):** `export DATABASE_URL="postgres://user:password@host:5432/dbname"`
+> 2. **Per-project (persistent, recommended):** add to `mise.toml` in this project
+>    (or an ancestor directory):
+>    ```toml
+>    [env]
+>    DATABASE_URL = "postgres://user:password@host:5432/dbname"
+>    ```
+>    Then re-run the task — `mise exec` will pick it up automatically.
+
+Do not proceed with any `psql`/`pg_dump` command until the existence check passes.
+
+### Expected mise.toml shape
+
+The project (or an ancestor directory) is expected to define something like:
+
+```toml
+[env]
+DATABASE_URL = "postgres://user:password@localhost:5432/mydb"
+```
+
+## Usage
+
+### Run a query
+
+```bash
+mise exec -- psql "$DATABASE_URL" -c "SELECT * FROM users LIMIT 10;"
+```
+
+### List tables
+
+```bash
+mise exec -- psql "$DATABASE_URL" -c "\dt"
+```
+
+### Describe a table
+
+```bash
+mise exec -- psql "$DATABASE_URL" -c "\d+ users"
+```
+
+### List schemas
+
+```bash
+mise exec -- psql "$DATABASE_URL" -c "\dn"
+```
+
+### Run a .sql file
+
+```bash
+mise exec -- psql "$DATABASE_URL" -f path/to/query.sql
+```
+
+### Dump schema only (no data)
+
+```bash
+mise exec -- pg_dump --schema-only "$DATABASE_URL"
+```
+
+## Output Handling
+
+`psql` output can be large (wide tables, big result sets). Prefer routing it through
+`ctx_execute`/`ctx_batch_execute` instead of raw `bash` when a query might return many
+rows or wide columns, so only the derived answer enters context:
+
+```javascript
+ctx_execute(language: "shell", code: `
+  mise exec -- psql "$DATABASE_URL" -At -F',' -c "SELECT id, email FROM users LIMIT 1000;"
+`)
+```
+
+Use `-At -F','` (unaligned, tuples-only, comma field separator) for machine-parseable
+output when you intend to filter/aggregate in code rather than eyeball it.
+
+## Safety
+
+- Treat any `INSERT`/`UPDATE`/`DELETE`/`DROP`/`TRUNCATE`/`ALTER` statement as a write —
+  confirm with the user before running it, unless they explicitly asked for that exact
+  change.
+- Default to read-only exploration (`SELECT`, `\d`, `\dt`, `EXPLAIN`) when the task is
+  "inspect" or "debug", not "modify."
+- Never read, print, or log the value of `$DATABASE_URL` (it contains credentials).
+  Only check existence (`test -n "$DATABASE_URL"`). Reference it by name in all
+  commands and output.
+- Never include full connection strings in commit messages, PR descriptions, or logs.


### PR DESCRIPTION
## Why

   pi agent lacked a skill for querying/inspecting Postgres databases. Ad-hoc psql
   commands risked leaking `DATABASE_URL` credentials into context and didn't guide
   the agent toward cheap schema discovery before falling back to source-code grepping.

   ## Approach

   Modeled after the existing skills in `templates/pi/skills/`. Kept the skill
   read-env-only (no `mise exec` wrapper) so it works regardless of shell activation,
   with `mise` only mentioned as a persistence option in the "DATABASE_URL absent"
   guidance. Added explicit rules against leaking even partial/truncated values
   (`head`, `cut`, `grep -o`, `awk`, slicing), since a leaked prefix can still expose
   scheme, user, or host.

   ## How it works

   Adds `templates/pi/skills/postgres/SKILL.md`:
   - Checks `DATABASE_URL` presence via `test -n` only — never reads/echoes/truncates it.
   - "Discovery First": run `\dt` before grepping application source when the task is
     to find/confirm data, since one cheap command beats multiple grep/read round-trips.
   - Standard usage recipes (query, list tables/schemas, describe table, run `.sql`
     file, schema-only dump).
   - Routes large `psql` output through `ctx_execute`/`ctx_batch_execute` instead of
     raw bash.
   - Safety rules: treat writes (`INSERT`/`UPDATE`/`DELETE`/`DROP`/`TRUNCATE`/`ALTER`)
     as requiring confirmation; default to read-only exploration for inspect/debug tasks.

   ## Links

   - N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PostgreSQL skill guide covering inspection, querying, schema discovery, and schema-dump workflows.
  * Included safeguards to prevent exposing connection details or credentials through command output.
  * Added guidance for large results, machine-readable output, and safer handling of sensitive data.
  * Documented confirmation requirements for state-changing operations and read-only exploration defaults.
  * Added transactional guidance for write scripts and fail-fast SQL execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->